### PR TITLE
Update MangaFox.js

### DIFF
--- a/MangaFox.js
+++ b/MangaFox.js
@@ -62,7 +62,8 @@ var MangaFox = {
   },
   getInformationsFromCurrentPage : function (doc, curUrl, callback) {
     "use strict";
-    var name = $('#related > h3 a', doc).text();
+    var str = $('#series > strong a',doc).text();// dom lookups are expensive!
+    var name = $('#related > h3 a', doc).text()||str.substring(0,str.length-6);//falls through #related, into #series 
     var currentChapter = $("#series h1", doc).text();
     var url = curUrl;
     var posSl5 = 0;


### PR DESCRIPTION
Assuming MangaFox.js is where the name for a manga in a list gets figured out, this should fix the issue where blank names are saved to the JSON config, as it falls through to "series" and cuts off the "manga" part from it. (series is definitely in every page, as it is the pointer to the root of the series)
