### PR TITLE
Update MangaFox.js

### DIFF
--- a/MangaFox.js
+++ b/MangaFox.js
@@ -124,7 +124,7 @@ var MangaFox = {
     $("#image", doc).remove();
     $("#tool", doc).next().remove();
     $("#viewer", doc).after("<div class='navAMR'></div>").before("<div class='navAMR'></div>");
-    $(".widepage.page", doc).remove();
+    $('.widepage').css('display','none'); //have to still have this for the series name.
     $('.fb_iframe_widget', doc).remove();
     if (typeof doc.createElement === 'function') {
       var script = doc.createElement('script');


### PR DESCRIPTION
Changed removed to hidden, so we can still hook the series name in code that gets executed later ( specifically, getInformationsFromCurrentPage is called afterwards, which means `var name = $('#related > h3 a', doc).text() || str.substring(0,
            str.length - 6); //falls through #related, into #series` fails if it needs to fall through
