### PR TITLE
Update MangaFox.js - Avoid grabbing cover image on chapter update

### DIFF
--- a/MangaFox.js
+++ b/MangaFox.js
@@ -48,6 +48,7 @@ var MangaFox = {
             },
             success: function(objResponse) {
                 var div = document.createElement("div");
+                objResponse = objResponse.replace(/<img\b[^>]*>/ig, ''); //avoid loading cover image
                 div.innerHTML = objResponse;
                 var res = [];
                 var mangaName = $('#title h2', div).text().substr(


### PR DESCRIPTION
Cover image is unnecessarily loaded every time MangaFox is checked for new chapter updates even though it is not used by AMR.
This avoids that by removing the image before it is attached to the DOM.