### PR TITLE
Fixes for Batoto & MangaFox + .gitattributes for normalized line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default line endings. This avoids issues with committing via different kinds of OS's.
+* text=auto

--- a/AdultManga.js
+++ b/AdultManga.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var AdultManga = {
   //Name of the mirror
   mirrorName : "AdultManga",
@@ -21,12 +19,10 @@ var AdultManga = {
   mirrorIcon : "img/readmanga.png",
   //Languages of scans for the mirror
   languages : "ru",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("adultmanga.ru/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -37,14 +33,12 @@ var AdultManga = {
           url: "http://adultmanga.ru/search",
           type: 'POST',
           data: {q: search},
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#mangaResults td a:first-child", div).each(function(index) {
@@ -55,8 +49,7 @@ var AdultManga = {
             callback("AdultManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -65,19 +58,15 @@ var AdultManga = {
      $.ajax(
         {
           url: urlManga+"?mature=1",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
 			var mng_nm = (urlManga.split('/')).pop();
-			
             $("div.expandable td > a", div).each(
                 function(index){
                     var str = $(this).attr("href");
@@ -87,16 +76,14 @@ var AdultManga = {
 					}
                  }
             );
-						
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -104,13 +91,11 @@ var AdultManga = {
     var nameurl = "http://adultmanga.ru" + $("#mangaBox h1 a:first-child", doc).attr("href");
     var curChapName = $("#chapterSelectorSelect:first option:selected", doc).text();
     var chapurl = "http://adultmanga.ru" + $("#chapterSelectorSelect:first option:selected", doc).val();
-   
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -134,20 +119,17 @@ var AdultManga = {
     });
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".baner", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#mangaBox", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -155,12 +137,10 @@ var AdultManga = {
     return $(".navAMR", doc);
     //return $("select[name='series']").parent().parent();
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("img#mangaPicture", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -172,12 +152,10 @@ var AdultManga = {
     $("#mangaBox", doc).css("padding-top", "10px");
     $("#mangaBox", doc).css("padding-bottom", "10px");
     $("#mangaBox", doc).css("border", "0");
-    
     $("#mangaBox", doc).css("background-color", "black");
     $("#mangaBox", doc).before($("<div class='navAMR'></div>"));
     $("#mangaBox", doc).after($("<div class='navAMR'></div>"));
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -187,7 +165,6 @@ var AdultManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -197,7 +174,6 @@ var AdultManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -206,33 +182,28 @@ var AdultManga = {
     //This function runs in the DOM of the current consulted page.
     $( image ).attr( "src", urlImg )
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#chapterSelectorSelect option", doc).each(function(index) {
       $(this).val("http://adultmanga.ru" + $(this).val());
     });
-    
     return $($("#chapterSelectorSelect", doc)[0]);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("AdultManga", AdultManga);

--- a/AkumaScan.js
+++ b/AkumaScan.js
@@ -126,7 +126,6 @@ var AkumaScan = {
       $("body > div:empty", doc).remove();
    }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Akuma Scan", AkumaScan);

--- a/AnarchyScans.js
+++ b/AnarchyScans.js
@@ -126,7 +126,6 @@ var AnarchyScans = {
     $("body > div:empty", doc).remove();
   }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Anarchy Scans", AnarchyScans);

--- a/AngelScanlator.js
+++ b/AngelScanlator.js
@@ -4,12 +4,10 @@ var AngelScanlator =
 	canListFullMangas: true,
 	mirrorIcon: "img/angelscanlator.png",
 	languages: "pt",
-
 	isMe: function(url)
 	{
 		return (url.indexOf("angelscanlator.com") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -23,12 +21,11 @@ var AngelScanlator =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
 				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$("select[name='manga'] option", div).each(function(index)
 				{
@@ -37,12 +34,10 @@ var AngelScanlator =
 						res.push([$(this).text(), 'http://angelscanlator.com/online/' + $(this).attr('value') + '/01']);
 					}
 				});
-
 				callback("Angel Scanlator", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -56,29 +51,25 @@ var AngelScanlator =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement( "div" ); 
+				var div = document.createElement( "div" );
 				div.innerHTML = objResponse;
-
 				var currentMangaURL = 'http://angelscanlator.com/online/' + $("select[name='manga']:first option[selected]", div).attr('value');
-
 				var res = [];
 				$("select[name='chapter']:first option", div).each(function(index)
 				{
 					res.push([$(this).text(), currentMangaURL + '/' + $(this).attr('value')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -87,16 +78,14 @@ var AngelScanlator =
 		var currentChapter = $("select[name='chapter']:first option[selected]", doc).text();
 		var currentMangaURL = 'http://angelscanlator.com/online/' + $("select[name='manga']:first option[selected]", doc).attr('value');
 		var currentChapterURL = currentMangaURL + '/' + $("select[name='chapter']:first option[selected]", doc).attr('value');
-
 		callback(
 		{
-			"name": name, 
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL + '/01', 
+			"name": name,
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL + '/01',
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -104,7 +93,6 @@ var AngelScanlator =
 	{
 		var currentMangaURL = 'http://angelscanlator.com/online/' + $("select[name='manga']:first option[selected]", doc).attr('value');
 		var currentChapterURL = currentMangaURL + '/' + $("select[name='chapter']:first option[selected]", doc).attr('value');
-
 		var res = [];
 		$("select[name='page']:first option", doc).each(function()
 		{
@@ -113,32 +101,27 @@ var AngelScanlator =
 		});
 		return res;
 	},
-
 	removeBanners: function(doc, curUrl)
 	{
 		//a lot of banners, huh?
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('.imgAMR', doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	whereDoIWriteNavigation: function(doc, curUrl)
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return ($("select[name='chapter']", doc).length > 0);
 	},
-
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -151,7 +134,6 @@ var AngelScanlator =
 		$('td.mid', doc).append($("<div class='navAMR'></div>"));
 		$(".navAMR").css("text-align", "center");
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -163,7 +145,6 @@ var AngelScanlator =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -175,7 +156,6 @@ var AngelScanlator =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -185,20 +165,17 @@ var AngelScanlator =
 	{
 		$.ajax(
 		{
-			url: urlImg,         
+			url: urlImg,
 			success: function(objResponse)
 			{
 				var div = document.createElement("div");
-				div.innerHTML = objResponse; 
-
+				div.innerHTML = objResponse;
 				var src = 'http://angelscanlator.com/online/' + $('img.picture', div).attr('src');
-
 				$(image).attr("src", src);
 			}
 		});
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -206,15 +183,13 @@ var AngelScanlator =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -223,7 +198,6 @@ var AngelScanlator =
 		$("body", doc).css('background-color', '#f5f5f5');
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Angel Scanlator", AngelScanlator);

--- a/AnimeA.js
+++ b/AnimeA.js
@@ -84,7 +84,7 @@ var AnimeA = {
     },
     doSomethingBeforeWritingScans: function (doc, curUrl) {
         $(".hca", doc).remove();
-        $(".h_contentmp", doc).empty();        
+        $(".h_contentmp", doc).empty();
         $(".h_contentmp", doc).before($("<div>").addClass("navAMR"));
         $(".h_contentmp", doc).after($("<div>").addClass("navAMR"));
     },
@@ -121,7 +121,6 @@ var AnimeA = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("AnimeA", AnimeA);

--- a/AnimeStory.js
+++ b/AnimeStory.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var AnimeStory = {
   //Name of the mirror
   mirrorName : "AnimeStory",
@@ -21,12 +19,10 @@ var AnimeStory = {
   mirrorIcon : "img/animestory.png",
   //Languages of scans for the mirror
   languages : "fr",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return ((url.indexOf("anime-story.com") != -1) || (url.indexOf("instantmanga.com") != -1));
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var AnimeStory = {
      $.ajax(
         {
           url: "http://www.anime-story.com/mangas/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#mangalist li a", div).each(function(index) {
@@ -55,8 +49,7 @@ var AnimeStory = {
             callback("AnimeStory", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -65,31 +58,27 @@ var AnimeStory = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $(".listchapseries li", div).each(function(index) {
               var txt = $(".chapter_series", $(this)).text();
               txt = txt.trim().replace(mangaName, "");
               res[res.length] = [txt, $("div:first a:last", $(this)).attr("href")];
-            }); 
+            });
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -97,24 +86,20 @@ var AnimeStory = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("#serie option:selected", doc).text();
     //currentMangaURL = $("#serie option:selected", doc).val().replace("http://www.anime-story.com/", "http://www.anime-story.com/mangas/");
     currentMangaURL = 'http://www.anime-story.com/mangas/' + $('#serie option:selected', doc).val();
     currentChapter = $("#pagenumber option:selected", doc).text();
     currentChapterURL = $("#pagenumber option:selected", doc).val();
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-            
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -128,32 +113,27 @@ var AnimeStory = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#ad").remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#nav", doc).add($("#navAMR", doc));
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#auto img", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -161,11 +141,9 @@ var AnimeStory = {
     $("#nav", doc).after($("<div id='scansAMR'></div>"));
     $("#nav", doc).empty();
     $("#nav", doc).css("text-align", "center");
-    
     $("#scansAMR", doc).after($("<div id='navAMR'></div>"));
     $("#navAMR", doc).css("text-align", "center");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -175,7 +153,6 @@ var AnimeStory = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -185,7 +162,6 @@ var AnimeStory = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -194,40 +170,34 @@ var AnimeStory = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: 'http://www.instantmanga.com/' + urlImg,         
+        url: 'http://www.instantmanga.com/' + urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("#auto a[rel=next] img", div).attr("src");
-          
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#pagenumber:first", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("AnimeStory", AnimeStory);

--- a/Animexis.js
+++ b/Animexis.js
@@ -5,14 +5,12 @@
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////
 */
-
 //This class is an example of manga site following implementation for All Manga Reader.
 //To test this class, just modify the json variable in mgEntry.js.
-//If your implementation works and has been fully tested, send it to me with an 
+//If your implementation works and has been fully tested, send it to me with an
 //icon (png with transparency file, 16x16) for your mirror
 //at pl dot duhoux (at) gmail dot com. I will add it in the extension.
 //If you have problems implementing your mirror, send me a mail... i will be glad to help you...
-
 //CHANGE here the classname
 var Animexis = {
   //CHANGE : Name of the mirror
@@ -22,12 +20,10 @@ var Animexis = {
   //CHANGE : Extension internal link to the icon of the mirror. (if not filled, will be blank...)
   mirrorIcon : "img/animexis.png",
   languages: "en",
-
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("manga.animexis.org/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -42,26 +38,22 @@ var Animexis = {
 		  {
 			'search': search
 		  },
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $('.list > .group > .title > a', div).each(function(index) {
 			  res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-
             callback("Animexis Scans", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -71,38 +63,32 @@ var Animexis = {
         {
           //CHANGE URL HERE
           url: urlManga,
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $('.list > .element > .title > a', div).each(function(index) {
               res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-            
             callback(res, obj);
           }
     });
   },
-
   /********************************************************************************************************
     IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
     However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
     of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
     the object doc (example, replace $("select") by $("select", doc) in jQuery).
   ********************************************************************************************************/
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -110,13 +96,11 @@ var Animexis = {
     var currentChapter = $('.tbtitle div a', doc)[1].text;
     var currentMangaURL = $('.tbtitle div a', doc)[0].href;
     var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -129,18 +113,15 @@ var Animexis = {
 	});
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     return $('#page', doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -149,12 +130,10 @@ var Animexis = {
     //you can change the DOM of the page before this method is called in doSomethingBeforeWritingScans
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return (curUrl.search('manga.animexis.org/reader/read/') > -1);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
 	script = doc.createElement('script');
@@ -166,7 +145,6 @@ var Animexis = {
     $("#page", doc).empty();
     $(".navAMR").css("text-align", "center");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -176,7 +154,6 @@ var Animexis = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -186,7 +163,6 @@ var Animexis = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -195,8 +171,7 @@ var Animexis = {
     //This function runs in the DOM of the current consulted page.
     $(image).attr("src", urlImg);
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
@@ -204,26 +179,21 @@ var Animexis = {
     //DO NOT CHANGE IF NOT NEEDED, NOT USED BY ANY EXISTING MIRROR AND CHAPTER'S DISPLAY IS WORKING FINE FOR THEM
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //RETURN A SELECT IF NEEDED, ELSE, THE EXTENSIOn WILL FIND CHAPTER BY IT'S OWN MEANS
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     //THE FOLLOWING LINE IS NECESSARY IN MOST OF CASES
     $("body > div:empty", doc).remove();
-    
     //DO ANYTHING ELSE YOU NEED
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Animexis Scans", Animexis);

--- a/Animextremist.js
+++ b/Animextremist.js
@@ -10,23 +10,16 @@ function formatMgName(name) {
   if (name == undefined || name == null || name == "null") return "";
   return name.trim().replace(/[^0-9A-Za-z]/g, '').toUpperCase();
 }
-
 var Animextremist = {
-
   mirrorName : "Animextremist",
-
   canListFullMangas : true,
-
   mirrorIcon : "img/animextremist.png",
-  
   //Languages of scans for the mirror
   languages : "es",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("animextremist.com/mangas-online") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,27 +28,22 @@ var Animextremist = {
      $.ajax(
         {
           url: "http://www.animextremist.com/mangas-online/mns.htm",
-
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
-
             $("option", div).each(function(index) {
       				if( $(this).attr("value") == "00") return;
       				res[res.length] = [$(this).text(), "http://www.animextremist.com/"+$(this).attr("value")];
             });
-
             callback("Animextremist", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -64,25 +52,19 @@ var Animextremist = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
             $("#Layer17 #tomos a", div).each(function(index) {
       				if( ! $(this).text()) return;
       				var ref = $(this).attr("href");
       				if( ref.indexOf("capitulo") == -1 ) return;
-      				
       				var texto = ref.replace(".html", "-1.html");
-      				
       				res[res.length] = [texto.replace(/(http:\/\/.*capitulo-)/,"").replace(/(\/.*)/,""), texto];
             });
 			      if( ! res.length ){
@@ -90,35 +72,29 @@ var Animextremist = {
       					if( ! $(this).text()) return;
       					var ref = $(this).attr("href");
       					if( ref.indexOf("capitulo") == -1 ) return;
-      					
       					var texto = ref;
-      					
       					res[res.length] = [texto.replace(/(http:\/\/.*capitulo-)/,"").replace(/(\/.*)/,""), texto];
     				  });
 			      }
-
       			res.sort(function( a, b){
       				var x = parseInt(a[0]);
       				var y = parseInt(b[0]);
       				return ((x < y) ? 1 : ((x > y) ? -1 : 0));
       			});
-                  
             callback(res, obj);
           }
       });
   },
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     var name;
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-    
     //FILL THE ABOVE VARIABLES HERE...
   	var manga = $("head title", doc).text();
   	var pos = manga.indexOf(" - ");
@@ -131,41 +107,35 @@ var Animextremist = {
      $.ajax(
         {
           url: "http://www.animextremist.com/mangas-online/mns.htm",
-
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var sent = false;
             $("option", div).each(function(index) {
       				if( $(this).attr("value") == "00") return;
       				var tmpname = $(this).text();
       				if (!sent && formatMgName(tmpname) == formatMgName(name)) {
-                currentMangaURL = "http://www.animextremist.com/"+$(this).attr("value");    
+                currentMangaURL = "http://www.animextremist.com/"+$(this).attr("value");
                 sent = true;
-                callback({"name": name, 
-                        "currentChapter": currentChapter, 
-                        "currentMangaURL": currentMangaURL, 
+                callback({"name": name,
+                        "currentChapter": currentChapter,
+                        "currentMangaURL": currentMangaURL,
                         "currentChapterURL": currentChapterURL});
               }
             });
           }
     });
-
-  }, 
-
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
   getListImages : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     var res = [];
-
     $("#nav-jump option", doc).each(
       function(index){
         res[index] = "http://www.animextremist.com/" + $(this).val();
@@ -173,32 +143,27 @@ var Animextremist = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
 	   $("#publi", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
 	   return $("#div-photo", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#nav", doc).add($("#sub-nav", doc));
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return $("#photo",doc).size() > 0;
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -208,9 +173,7 @@ var Animextremist = {
 	  $("#nav", doc).empty();
 	  $("#sub-nav", doc).empty();
     $("#div-photo", doc).empty();
-    
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -220,7 +183,6 @@ var Animextremist = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -230,7 +192,6 @@ var Animextremist = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -243,45 +204,40 @@ var Animextremist = {
   		beforeSend: function(xhr) {
   			xhr.setRequestHeader("Cache-Control", "no-cache");
   			xhr.setRequestHeader("Pragma", "no-cache");
-  		}, 
+  		},
   		success: function( objResponse ){
-  			var div = document.createElement( "div" );  
+  			var div = document.createElement( "div" );
   			div.innerHTML = objResponse;
-  
   			var src = $("#photo",div).attr("src");
   			$( image ).attr( "src", src);
   		}
   	});
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
-    //This function runs in the DOM of the current consulted page. 
+    //This function runs in the DOM of the current consulted page.
     var select = $("<select></select>");
     var listOptions = [];
-      
     var URL = curUrl.substr(0,curUrl.lastIndexOf("/"));
     $("iframe", doc).each(function(index){
     	if( index == 1 )
     		URL = URL + "/" + $(this).attr("src");
       });
-    
     $.ajax({
         url: URL,
     	  async: false,
         beforeSend: function(xhr) {
           xhr.setRequestHeader("Cache-Control", "no-cache");
           xhr.setRequestHeader("Pragma", "no-cache");
-        }, 
+        },
         success: function( objResponse ){
           var div = document.createElement( "div" );
           div.innerHTML = objResponse;
@@ -298,18 +254,15 @@ var Animextremist = {
     		  });
         }
     });
-
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    //$("body > div:empty", doc).remove();  
-    $($("table > tbody > tr > td > center")[0]).remove();  
+    //$("body > div:empty", doc).remove();
+    $($("table > tbody > tr > td > center")[0]).remove();
 	  return;
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Animextremist", Animextremist);

--- a/BacaManga.js
+++ b/BacaManga.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var BacaManga = {
   //Name of the mirror
   mirrorName : "BacaManga",
@@ -21,12 +19,10 @@ var BacaManga = {
   mirrorIcon : "img/bacamanga.png",
   //Languages of scans for the mirror
   languages : "id",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("komikid.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var BacaManga = {
      $.ajax(
         {
           url: "http://komikid.com/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("select[name='manga']:first option", div).each(function(index) {
@@ -53,8 +47,7 @@ var BacaManga = {
             callback("BacaManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,33 +56,27 @@ var BacaManga = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
             $("select[name='chapter']:first option", div).each(
                 function(index){
                     res[res.length] = [$(this).text(), urlManga + "/" + $(this).val()];
                  }
             );
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -97,13 +84,11 @@ var BacaManga = {
     var nameurl = "http://komikid.com/" + $("select[name='manga']:first option:selected", doc).val();
     var curChapName = $("select[name='chapter']:first option:selected", doc).text();
     var chapurl = nameurl + "/" + $("select[name='chapter']:first option:selected", doc).val();
-   
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -111,27 +96,23 @@ var BacaManga = {
     //This function runs in the DOM of the current consulted page.
     var nameurl = "http://komikid.com/" + $("select[name='manga']:first option:selected", doc).val();
     var chapurl = nameurl + "/" + $("select[name='chapter']:first option:selected", doc).val();
-   
     var res = [];
     $("select[name='page']:first option", doc).each(function(index) {
       res[res.length] = chapurl + "/" + $(this).val();
     });
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".baner", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -139,12 +120,10 @@ var BacaManga = {
     return $(".navAMR", doc);
     //return $("select[name='series']").parent().parent();
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("img.picture", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -156,7 +135,6 @@ var BacaManga = {
     $(".navAMR", doc).css("text-align", "center");
     $(".scanAMR", doc).css("background-color", "black");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -166,7 +144,6 @@ var BacaManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -176,7 +153,6 @@ var BacaManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -188,36 +164,29 @@ var BacaManga = {
           url: urlImg,
           success: function( objResponse ){
             var div = document.createElement( "div" );
-            div.innerHTML = objResponse; 
-      
-            var src = "http://komikid.com/" + $("img.picture", div).attr("src"); 
-        
+            div.innerHTML = objResponse;
+            var src = "http://komikid.com/" + $("img.picture", div).attr("src");
             $( image ).attr( "src", src );
           }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     var nameurl = "http://komikid.com/" + $("select[name='manga']:first option:selected", doc).val();
-    
     $("select[name='chapter']:first option", doc).each(function(index) {
       $(this).val(nameurl + "/" + $(this).val());
     });
-    
     return $("select[name='chapter']:first", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -225,7 +194,6 @@ var BacaManga = {
     $("#omv .scanAMR table").css("background-color", "black");
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("BacaManga", BacaManga);

--- a/Batoto.js
+++ b/Batoto.js
@@ -16,85 +16,94 @@ var Batoto = {
                 xhr.setRequestHeader("Pragma", "no-cache");
             },
             success: function (objResponse) {
-                var div = document.createElement("div");
+                var div       = document.createElement("div");
                 div.innerHTML = objResponse.replace(/<img/gi, '<noload');
-                $("#comic_search_results .chapters_list tr a", div).each(function (index) {
-                    $.ajax({
-                        url: $(this).attr("href"),
-                        beforeSend: function (xhr) {
-                            xhr.setRequestHeader("Cache-Control", "no-cache");
-                            xhr.setRequestHeader("Pragma", "no-cache");
-                        },
-                        success: function (objResponse) {
-                            var divIn = document.createElement("div"),
-                                res = [];
-                            divIn.innerHTML = objResponse.replace(/<img/gi,
-                                '<noload');
-                            if ($(".lang_English:eq(-1) a:first", divIn) !==
-                                null) {
-                                res[res.length] = [$(".ipsType_pagetitle",
-                                    divIn).text().trim(), $(
-                                    ".lang_English:eq(-1) a:first",
-                                    divIn).attr('href')];
-                            }
-                            /* if ($(".chapters_list .row:not(.lang_English)", divIn).attr('href') !== null) {
-                                I couldn't test this piece of code
-                                res[res.length] = [$(".ipsType_pagetitle", divIn).text().trim(), $(this).attr('href')];
-                            }
-                            */
-                            callback("Batoto", res);
-                        }
+
+                if (objResponse.indexOf("Sorry, the page you are looking for is currently unavailable.") !== -1) {
+                    callback("Batoto", []);
+                } else {
+                    var res = [];
+                    $("#comic_search_results .chapters_list tr a[href*='/comic/']", div).each(function (index) {
+                        res[index] = [$(this).text().trim(), $(this).attr("href")];
                     });
-                });
+                    callback("Batoto", res);
+                }
             }
         });
     },
     getListChaps: function (urlManga, mangaName, obj, callback) {
         "use strict";
-        $.ajax({
-            url: urlManga,
-            beforeSend: function (xhr) {
-                xhr.setRequestHeader("Cache-Control", "no-cache");
-                xhr.setRequestHeader("Pragma", "no-cache");
-            },
-            success: function (objResponse) {
-                var div = document.createElement("div"),
-                    res = [];
-                div.innerHTML = objResponse.replace(/<img/gi, '<noload');
-                var res = [];
-                $(".moderation_bar:first [name='chapter_select'] option", div).each(function (index) {
-                    res[index] = [$(this).text().trim(), $(this).val()];
-                });
-                callback(res, obj);
-            }
-        });
+        if (typeof urlManga === 'undefined') {
+            //this shouldn't happen but it does :|
+            callback([['FIXME: Something went wrong...', 'http://bato.to']], obj);
+        } else if(urlManga.indexOf('http://bato.to/read/') !== -1) {
+            //let's avoid hammering the servers with dead URLs
+            callback([['FIXME: Using old url format', 'http://bato.to']], obj);
+        } else {
+            $.ajax({
+                url: urlManga,
+                beforeSend: function (xhr) {
+                    xhr.setRequestHeader("Cache-Control", "no-cache");
+                    xhr.setRequestHeader("Pragma", "no-cache");
+                },
+                success: function (objResponse) {
+                    var div       = document.createElement("div"),
+                        res = [];
+                    div.innerHTML = objResponse.replace(/<img/gi, '<noload');
+
+                    var res       = [];
+                    $('.chapter_row', div).each(function (index) {
+                        var ch    = $(this).find('td:eq(0) > a');
+                        var title = $(ch).text().trim(),
+                            url   = $(ch).attr('href');
+                        //"http://bato.to/areader?id="+$(ch).attr('href').split('#')[1]+"&p=1"
+                        res[res.length] = [title, url];
+                    });
+                    callback(res, obj);
+                }
+            });
+        }
     },
     getInformationsFromCurrentPage: function (doc, curUrl, callback) {
-        var mod_bar = $(".moderation_bar:first", doc);
-        var chapter = $("[name='chapter_select'] option:selected", mod_bar);
-        var manga = $("ul:first-child a", mod_bar);
-        var name = manga.text();
-        var group = $("select[name='group_select']:first option:selected", doc).text();
-        if (group && group != "") {
-            var gps = group.split(" ");
-            var lang;
-            var i = gps.length - 1;
-            while ((lang = gps[i]) == "" && i >= 0) {
-                i--;
+        //Delay until loaded.
+        var dfd = $.Deferred();
+        var attempts = 0;
+        var checkSelector = setInterval(function () {
+            if ($('#reader', doc).text() !== 'Loading...') {
+                dfd.resolve();
+                console.log("forever loading");
+                clearInterval(checkSelector);
+            } else {
+                //FIXME: This fails tests for some reason. Probably due to AJAX nonsense.
             }
-            if (lang != "English" && lang != "") {
-                name += " (" + lang + ")";
+        }, 1000);
+        dfd.done(function () {
+            var mod_bar = $(".moderation_bar:first", doc);
+            var chapter = $("[name='chapter_select'] option:selected", mod_bar);
+            var manga   = $("ul:first-child a:eq(0)", mod_bar);
+            var name    = manga.text();
+            var group   = $("select[name='group_select']:first option:selected", doc).text();
+            if (group && group != "") {
+                var gps = group.split(" ");
+                var lang;
+                var i   = gps.length - 1;
+                while ((lang = gps[i]) == "" && i >= 0) {
+                    i--;
+                }
+                if (lang != "English" && lang != "") {
+                    name += " (" + lang + ")";
+                }
             }
-        }
-        var currentChapter = chapter.text();
-        var pos = $("[name='chapter_select'] option:last", mod_bar).val().lastIndexOf("/");
-        var currentMangaURL = $("[name='chapter_select'] option:last", mod_bar).val();
-        var currentChapterURL = chapter.val();
-        callback({
-            "name": name,
-            "currentChapter": currentChapter,
-            "currentMangaURL": currentMangaURL,
-            "currentChapterURL": currentChapterURL
+            var currentChapter    = chapter.text();
+            var pos               = $("[name='chapter_select'] option:last", mod_bar).val().lastIndexOf("/");
+            var currentMangaURL   = $(manga).attr('href');
+            var currentChapterURL = chapter.val();
+            callback({
+                "name": name,
+                "currentChapter": currentChapter,
+                "currentMangaURL": currentMangaURL,
+                "currentChapterURL": currentChapterURL
+            });
         });
     },
     getListImages: function (doc, curUrl) {
@@ -102,7 +111,11 @@ var Batoto = {
         var res = [];
         if ($(".moderation_bar:first #page_select option", doc).size() > 0) {
             $(".moderation_bar:first #page_select option", doc).each(function (index) {
-                res[index] = $(this).val();
+                var split = $(this).val().split('#')[1].split('_'),
+                    id    = split[0],
+                    page  = split[1] || 1;
+
+                res[index] = "http://bato.to/areader?id="+id+"&p="+page;
             });
         } else {
             $('#content > div > img', doc).each(function (index) {
@@ -124,8 +137,7 @@ var Batoto = {
     },
     isCurrentPageAChapterPage: function (doc, curUrl) {
         "use strict";
-        return ($("#comic_page", doc).size() > 0 || $("#full_image", doc).size() > 0 || curUrl.indexOf(/read/) !==
-            -1);
+        return ($("#comic_page", doc).size() > 0 || $("#full_image", doc).size() > 0 || curUrl.search(/\/reader#/) !== -1);
     },
     doSomethingBeforeWritingScans: function (doc, curUrl) {
         "use strict";
@@ -140,6 +152,7 @@ var Batoto = {
         mod_bar.css("height", "8px");
         mod_bar.css("margin-bottom", "0px");
         mod_bar.css("padding-top", "0px");
+
         if ($("#comic_page", doc).parent().size() > 0) {
             $("#comic_page", doc).parent().remove();
             $("<div class='AMRcomic'></div>").appendTo($(".amrcontainer", doc));
@@ -174,9 +187,9 @@ var Batoto = {
             $.ajax({
                 url: urlImg,
                 success: function (objResponse) {
-                    var div = document.createElement("div");
-                    div.innerHTML = objResponse;
-                    var src = $("img#comic_page", div).attr("src");
+                    var div       = document.createElement("div");
+                    div.innerHTML = objResponse.replace(/<img/gi, '<noload');;
+                    var src       = $("noload#comic_page", div).attr("src");
                     $(image).attr("src", src);
                 }
             });
@@ -198,13 +211,14 @@ var Batoto = {
         $("#full_image", doc).css("display", "");
         $("#content", doc).css("width", "auto !important");
         if (typeof doc.createElement === 'function') {
-            var script = doc.createElement('script');
+            var script       = doc.createElement('script');
             script.innerText = "Hotkeys.hotkeys.clear();";
             doc.body.appendChild(script);
         }
     }
 };
+
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
-	registerMangaObject("Batoto", Batoto);
+    registerMangaObject("Batoto", Batoto);
 }

--- a/Batoto.js
+++ b/Batoto.js
@@ -140,7 +140,6 @@ var Batoto = {
         mod_bar.css("height", "8px");
         mod_bar.css("margin-bottom", "0px");
         mod_bar.css("padding-top", "0px");
-
         if ($("#comic_page", doc).parent().size() > 0) {
             $("#comic_page", doc).parent().remove();
             $("<div class='AMRcomic'></div>").appendTo($(".amrcontainer", doc));
@@ -205,7 +204,6 @@ var Batoto = {
         }
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Batoto", Batoto);

--- a/CXCScans.js
+++ b/CXCScans.js
@@ -14,11 +14,11 @@ var CXCScans = {
                     xhr.setRequestHeader("Cache-Control", "no-cache");
                     xhr.setRequestHeader("Pragma", "no-cache");
                     xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
-                }, 
+                },
                 type: 'POST',
                 data: {
                     'search': search
-                }, 
+                },
                 success: function(objResponse){
                     var div = document.createElement("div"),
                         res = [];
@@ -26,11 +26,10 @@ var CXCScans = {
                     $('.panel .group > .title a', div).each(function(index) {
                         res[res.length] = [$(this).attr('title'), $(this).attr('href')];
                     });
-
                     callback("CXC Scans", res);
                 }
             });
-    }, 
+    },
     getListChaps : function(urlManga, mangaName, obj, callback) {
         $.ajax(
             {
@@ -42,9 +41,9 @@ var CXCScans = {
                     xhr.setRequestHeader("Cache-Control", "no-cache");
                     xhr.setRequestHeader("Pragma", "no-cache");
                     xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
-                }, 
+                },
                 success: function(objResponse){
-                    var div = document.createElement( "div" ); 
+                    var div = document.createElement( "div" );
                     div.innerHTML = objResponse.replace(/<img/gi, '<noload');
                     var res = [];
                     $('.list .group .title a', div).each(function(index) {
@@ -59,14 +58,14 @@ var CXCScans = {
         var currentChapter = $('.tbtitle div a', doc)[1].text;
         var currentMangaURL = $('.tbtitle div a', doc)[0].href;
         var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-        callback({"name": name, 
-                  "currentChapter": currentChapter, 
-                  "currentMangaURL": currentMangaURL, 
+        callback({"name": name,
+                  "currentChapter": currentChapter,
+                  "currentMangaURL": currentMangaURL,
                   "currentChapterURL": currentChapterURL});
-    }, 
+    },
     getListImages : function(doc, curUrl) {
         var res = [],
-            pages = JSON.parse($('body', doc).html().match(/pages\s?=\s?.*];/)[0].replace(/pages\s?=\s?/,"").replace(/;$/,""));        
+            pages = JSON.parse($('body', doc).html().match(/pages\s?=\s?.*];/)[0].replace(/pages\s?=\s?/,"").replace(/;$/,""));
         pages.forEach(function(page) {
             res.push(page.url);
         });
@@ -128,7 +127,6 @@ var CXCScans = {
         $("#page", doc).css("max-width", "none");
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("CXC Scans", CXCScans);

--- a/CentralDeMangas.js
+++ b/CentralDeMangas.js
@@ -4,12 +4,10 @@ var CentralDeMangas =
 	canListFullMangas: true,
 	mirrorIcon: "img/centraldemangas.png",
 	languages: "pt",
-
 	isMe: function(url)
 	{
 		return (url.indexOf("centraldemangas.com.br/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -23,23 +21,20 @@ var CentralDeMangas =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$("#conteudo table.tbl_mangas tbody tr td:first-child a", div).each(function(index)
 				{
 					res[res.length] = [$(this).text(), $(this).attr("href")];
 				});
-
 				callback("Central De Mangas", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -53,28 +48,25 @@ var CentralDeMangas =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function( objResponse )
 			{
 				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$("div a", $("#conteudo .bloco:last-child", div)).each(function(index)
 				{
 					res[res.length] = [$(this).text(), $(this).attr("href") + '#1'];
 				});
 				res.reverse();
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -84,26 +76,21 @@ var CentralDeMangas =
 		var currentMangaURL;
 		var currentChapterURL;
 		var pos;
-
 		name = $("label[for='capitulos']", doc).text();
 		pos = name.indexOf(":");
 		name = name.substring(pos + 1, name.length).trim();
-
 		currentChapter = $("#capitulos option:selected", doc).text();
 		currentChapterURL = $("#capitulos option:selected", doc).val() + '#1';
 		pos = currentChapterURL.lastIndexOf("/");
 		currentMangaURL = currentChapterURL.substr(0, pos);
-
-
 		callback(
 		{
-			"name": name, 
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"name": name,
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
 	},
-
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -111,21 +98,17 @@ var CentralDeMangas =
 	getListImages: function(doc, curUrl)
 	{
 		var res;
-
 		$("script", doc).each(function(index)
 		{
 			if ($(this).text().indexOf("var pags = ") != -1)
 			{
 				var posdeb = $(this).text().indexOf("var pags = ");
-				var posfin = $(this).text().indexOf("]", posdeb); 
-
+				var posfin = $(this).text().indexOf("]", posdeb);
 				res = eval($(this).text().substring(posdeb + 11, posfin + 1));
 			}
 		});
-
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
@@ -133,7 +116,6 @@ var CentralDeMangas =
 		$("#anuncio_a").remove();
 		$("#anuncio_b").remove();
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -141,7 +123,6 @@ var CentralDeMangas =
 	{
 		return $(".pagina", doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -149,13 +130,11 @@ var CentralDeMangas =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return ($("#img_pag", doc).size() > 0);
 	},
-
 	//This method is called before displaying full chapters in the page
 	//This function runs in the DOM of the current consulted page.
 	doSomethingBeforeWritingScans: function(doc, curUrl)
@@ -165,7 +144,6 @@ var CentralDeMangas =
 		$("select[name='paginas']", doc).remove();
 		$("ul.seletores", doc).remove();
 		$("iframe", doc).remove();
-
 		$(".pagina", doc).empty();
 		$(".pagina", doc).css("background-color", "black");
 		$(".pagina", doc).css("padding-top", "10px");
@@ -173,7 +151,6 @@ var CentralDeMangas =
 		$(".pagina", doc).after($("<div class='navAMR'></div>"));
 		$(".navAMR", doc).css("text-align", "center");
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -185,7 +162,6 @@ var CentralDeMangas =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -197,7 +173,6 @@ var CentralDeMangas =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -207,8 +182,7 @@ var CentralDeMangas =
 	{
 		$(image).attr( "src", urlImg )
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -216,15 +190,13 @@ var CentralDeMangas =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;//$("#capitulos", doc);
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -238,7 +210,6 @@ var CentralDeMangas =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Central De Mangas", CentralDeMangas);

--- a/CityManga.js
+++ b/CityManga.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var CityManga = {
   //Name of the mirror
   mirrorName : "CityManga",
@@ -21,12 +19,10 @@ var CityManga = {
   mirrorIcon : "img/citymanga.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("citymanga.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var CityManga = {
      $.ajax(
         {
           url: "http://www.citymanga.com/manga-list/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#main_container #allwide .roww2 .coll1 a", div).each(function(index) {
@@ -51,8 +45,7 @@ var CityManga = {
             callback("CityManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -61,16 +54,13 @@ var CityManga = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $("#main_container #fullwidth .roww2 .coll1 a", div).each(function(index) {
               res[res.length] = [$(this).attr("title").replace(mangaName, "").trim(), $(this).attr("href")];
@@ -79,11 +69,10 @@ var CityManga = {
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -91,28 +80,23 @@ var CityManga = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("#main_container #linkkkk span a", doc).text().trim();
     currentMangaURL = "http://www.citymanga.com" + $("#main_container #linkkkk > span a", doc).attr("href");
-    
     currentChapter = $("#main_container #linkkkk > h1", doc).text().replace(name, "").trim();
     var ref = curUrl;
     var pos = ref.lastIndexOf("chapter-");
     var slash = ref.indexOf("/", pos);
     ref = ref.substr(0, slash) + "/";
     currentChapterURL = ref;
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -130,33 +114,28 @@ var CityManga = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#seventwentyeight", doc).remove();
     $("#seventwentyeight300", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#main_container2", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#selector", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#main_container2 img.image", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -167,7 +146,6 @@ var CityManga = {
     $("#main_container", doc).css("width", "auto");
     $("#main_container #linkkkk", doc).css("background-color", "black");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -177,7 +155,6 @@ var CityManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -187,7 +164,6 @@ var CityManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -196,27 +172,23 @@ var CityManga = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = "http://www.citymanga.com" + $("#main_container2 img.image", div).attr("src");
-          
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -225,17 +197,14 @@ var CityManga = {
     $("#chapterselector:first option", doc).each(function(index) {
       $(this).val(ref.substr(0, pos) + "chapter-" + $(this).val() + "/");
     });
-    
     return $("#chapterselector:first", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("CityManga", CityManga);

--- a/ClockworkLies.js
+++ b/ClockworkLies.js
@@ -41,7 +41,6 @@ getMangaList: function (search, callback) {
 	doAfterMangaLoaded: function (doc, curUrl) {
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Clockwork Lies", ClockworkLies);

--- a/DragonFlyScans.js
+++ b/DragonFlyScans.js
@@ -131,7 +131,6 @@ var DragonFlyScans = {
     $("body > div:empty", doc).remove();
   }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Dragon & Fly Scans", DragonFlyScans);

--- a/DynastyScans.js
+++ b/DynastyScans.js
@@ -120,7 +120,6 @@ var DynastyScans = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Dynasty Scans", DynastyScans);

--- a/EJapanzai.js
+++ b/EJapanzai.js
@@ -165,7 +165,6 @@ var EJapanzai = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Ecchi Japanzai", EJapanzai);

--- a/EasyGoing.js
+++ b/EasyGoing.js
@@ -128,7 +128,6 @@ var EasyGoing = {
         $('option', doc).css('background-color', 'white').css('color', 'black');
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Easy Going", EasyGoing);

--- a/EatManga.js
+++ b/EatManga.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var EatManga = {
   //Name of the mirror
   mirrorName : "EatManga",
@@ -21,12 +19,10 @@ var EatManga = {
   mirrorIcon : "img/eatmanga.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("eatmanga.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var EatManga = {
      $.ajax(
         {
           url: "http://eatmanga.com/Manga-Scan/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#updates tr th a:first-child", div).each(function(index) {
@@ -51,8 +45,7 @@ var EatManga = {
             callback("EatManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -61,18 +54,14 @@ var EatManga = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
             $("#updates tr th a:first-child", div).each(function(index) {
               if (index == 0) {
                 var _self = this;
@@ -82,8 +71,7 @@ var EatManga = {
                     url: "http://eatmanga.com" + $(_self).attr("href"),
                     success: function( objResponse ){
                       var div = document.createElement( "div" );
-                      div.innerHTML = objResponse; 
-                
+                      div.innerHTML = objResponse;
                       if ($("img.eatmanga_bigimage", div).size() > 0) {
                         res[res.length] = [$(_self).text().trim(), "http://eatmanga.com" + $(_self).attr("href")];
                       }
@@ -93,16 +81,14 @@ var EatManga = {
                 res[res.length] = [$(this).text().trim(), "http://eatmanga.com" + $(this).attr("href")];
               }
             });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -121,13 +107,11 @@ var EatManga = {
     } else {
       chapurl = nameurl + tmpu + "/";
     }
-
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -139,33 +123,28 @@ var EatManga = {
     });
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".baner", doc).remove();
     $("iframe", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#eatmanga_image_big", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -179,7 +158,6 @@ var EatManga = {
     $("#main_inner", doc).css("width", "100%");
     $("#main_inner", doc).css("padding", "0");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -189,7 +167,6 @@ var EatManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -199,7 +176,6 @@ var EatManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -211,42 +187,35 @@ var EatManga = {
         url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("[id^='eatmanga_image']", div).attr("src");
-    
           $( image ).attr( "src", src );
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     /*$("select#chapters:first option", doc).each(function(index) {
       $(this).val("http://eatmanga.com" + $(this).val());
     });
-    
     return $("select#chapters:first", doc);*/
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("EatManga", EatManga);

--- a/EvilFlowers.js
+++ b/EvilFlowers.js
@@ -126,7 +126,6 @@ var EvilFlowers = {
       $("body > div:empty", doc).remove();
    }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Evil Flowers", EvilFlowers);

--- a/ExtrasScans.js
+++ b/ExtrasScans.js
@@ -130,7 +130,6 @@ var ExtrasScans = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Extras Scans", ExtrasScans);

--- a/FTHScans.js
+++ b/FTHScans.js
@@ -130,7 +130,6 @@ var FTHScans = {
       $("body > div:empty", doc).remove();
    }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("For The Halibut", FTHScans);

--- a/FoolRulez.js
+++ b/FoolRulez.js
@@ -124,7 +124,6 @@ var FoolRulez = {
       $("body > div:empty", doc).remove();
    },
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("FoOlRulez", FoolRulez);

--- a/GaoSubs.js
+++ b/GaoSubs.js
@@ -139,7 +139,6 @@ var GaoSubs = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Gao-subs", GaoSubs);

--- a/GodHandScans.js
+++ b/GodHandScans.js
@@ -4,13 +4,11 @@ var GodHandScans =
 	canListFullMangas: true,
 	mirrorIcon: "img/godhandscans.png",
 	languages: "pt",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("godhandscans.com.br/manga/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -24,23 +22,20 @@ var GodHandScans =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('tr:has(td.chapter) td.series a', div).each(function(index)
 				{
 					res.push([$(this).text(), $(this).attr('href')]);
 				});
-
 				callback("God Hand Scans", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -54,28 +49,24 @@ var GodHandScans =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
-
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div"); 
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('td.series a', div).each(function(index)
 				{
 					res.push([$(this).text(), $(this).attr('href')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -84,16 +75,14 @@ var GodHandScans =
 		var currentChapter = $('select.viewerChapter:first option:selected', doc).text();
 		var currentMangaURL = $('h2 a', doc).attr('href');
 		var currentChapterURL = currentMangaURL + $('select.viewerChapter:first option:selected', doc).attr('value') + '/';
-
 		callback(
 		{
 			"name": name,
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -101,7 +90,6 @@ var GodHandScans =
 	{
 		var currentMangaURL = $('h2 a', doc).attr('href');
 		var currentChapterURL = currentMangaURL + $('select.viewerChapter:first option:selected', doc).attr('value') + '/';
-
 		var res = [];
 		$('select.viewerPage:first option', doc).each(function()
 		{
@@ -109,21 +97,18 @@ var GodHandScans =
 		});
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		$("iframe", doc).remove();
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('.imgAMR', doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -131,7 +116,6 @@ var GodHandScans =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
@@ -141,7 +125,6 @@ var GodHandScans =
 		}
 		return false;
 	},
-
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -152,7 +135,6 @@ var GodHandScans =
 		$("#content", doc).append($("<div class='imgAMR'></div>"));
 		$("#content", doc).append($("<div class='navAMR'></div>"));
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -164,7 +146,6 @@ var GodHandScans =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -176,7 +157,6 @@ var GodHandScans =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -186,20 +166,17 @@ var GodHandScans =
 	{
 		$.ajax(
 		{
-			url: urlImg,         
+			url: urlImg,
 			success: function(objResponse)
 			{
 				var div = document.createElement("div");
-				div.innerHTML = objResponse; 
-
+				div.innerHTML = objResponse;
 				var src = $('#imageWrapper img', div).attr('src');
-
 				$(image).attr("src", src);
 			}
 		});
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -207,15 +184,13 @@ var GodHandScans =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -223,7 +198,6 @@ var GodHandScans =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("God Hand Scans", GodHandScans);

--- a/GoodManga.js
+++ b/GoodManga.js
@@ -120,7 +120,6 @@ var GoodManga = {
         $("body > div:empty", doc).remove();
     }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("GoodManga", GoodManga);

--- a/Haruka.js
+++ b/Haruka.js
@@ -4,13 +4,11 @@ var Haruka =
 	canListFullMangas: false,
 	mirrorIcon: "img/haruka.png",
 	languages: "pt",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("leitor.haru-ka.net") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -29,23 +27,20 @@ var Haruka =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('.list > .group > .title > a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback("Haru-ka", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -59,28 +54,24 @@ var Haruka =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
-
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div"); 
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('.list > .element > .title > a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -89,16 +80,14 @@ var Haruka =
 		var currentChapter = $('.tbtitle div a', doc)[1].text;
 		var currentMangaURL = $('.tbtitle div a', doc)[0].href;
 		var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-
 		callback(
 		{
 			"name": name,
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -112,21 +101,18 @@ var Haruka =
 		});
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		// No ads here
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('#page', doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -134,13 +120,11 @@ var Haruka =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return (curUrl.search('leitor.haru-ka.net/reader/read/') > -1);
 	},
-
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -162,7 +146,6 @@ var Haruka =
 			$("#page", doc).css("width", "100%");
 		});
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -174,7 +157,6 @@ var Haruka =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -186,7 +168,6 @@ var Haruka =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -196,8 +177,7 @@ var Haruka =
 	{
 		$(image).attr("src", urlImg);
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -205,15 +185,13 @@ var Haruka =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -221,7 +199,6 @@ var Haruka =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Haru-ka", Haruka);

--- a/HimawariMangas.js
+++ b/HimawariMangas.js
@@ -1,15 +1,13 @@
-var HimawariMangas = 
+var HimawariMangas =
 {
 	mirrorName: "Himawari Mangás",
 	canListFullMangas: true,
 	mirrorIcon: "img/himawarimangas.png",
 	languages: "pt",
-
 	isMe : function(url)
 	{
 		return (url.indexOf("read.himawarimangas.com.br/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -23,10 +21,10 @@ var HimawariMangas =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
 				var res = [];
 				$(".selector2 .options a", div).each(function(index)
@@ -36,8 +34,7 @@ var HimawariMangas =
 				callback("Himawari Mangás", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -51,23 +48,20 @@ var HimawariMangas =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div"); 
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$(".theList .chapter", div).each(function(index)
 				{
 					res.push([$("b", $(this)).text().trim(), "http://read.himawarimangas.com.br/" + $("a", $(this)).attr("href")]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
 	retrieveInfo: function(sel)
 	{
 		var _obj = {};
@@ -83,11 +77,10 @@ var HimawariMangas =
 		});
 		return _obj;
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -96,23 +89,20 @@ var HimawariMangas =
 		var currentChapter;
 		var currentMangaURL;
 		var currentChapterURL;
-
 		var manga = HimawariMangas.retrieveInfo($($(".selector2", doc)[0]));
 		var chapter = HimawariMangas.retrieveInfo($($(".selector2", doc)[1]));
 		name = manga.name;
 		currentChapter = chapter.name;
 		currentChapterURL = chapter.url;
 		currentMangaURL = manga.url;
-
 		callback(
 		{
-			"name": name, 
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"name": name,
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -138,14 +128,12 @@ var HimawariMangas =
 		res.pop()
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		$(".ads", doc).remove();
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -153,7 +141,6 @@ var HimawariMangas =
 	{
 		return $(".scanAMR", doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -161,13 +148,11 @@ var HimawariMangas =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return ($("#theManga #thePic", doc).size() > 0);
 	},
-
 	//This method is called before displaying full chapters in the page
 	//This function runs in the DOM of the current consulted page.
 	doSomethingBeforeWritingScans: function(doc, curUrl)
@@ -191,7 +176,6 @@ var HimawariMangas =
 		$("<div class='navAMR'></div>").appendTo($("#amrManga", doc));
 		$(".navAMR", doc).css("text-align", "center");
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -203,7 +187,6 @@ var HimawariMangas =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -215,7 +198,6 @@ var HimawariMangas =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -225,8 +207,7 @@ var HimawariMangas =
 	{
 		$(image).attr("src", urlImg);
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -234,8 +215,7 @@ var HimawariMangas =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
@@ -255,8 +235,7 @@ var HimawariMangas =
 			$("<option value=\"" + "http://read.himawarimangas.com.br/" + $(this).attr("href") + "\"" + (iscur ? "selected=\"selected\"" : "") + ">" + $(".option", $(this)).text().trim() + "</option>").appendTo(ret);
 		});
 		return ret;
-	},  
-
+	},
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded : function(doc, curUrl)
@@ -265,7 +244,6 @@ var HimawariMangas =
 		$('#infoSpread').hide();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Himawari Mangás", HimawariMangas);

--- a/Imangascans.js
+++ b/Imangascans.js
@@ -140,7 +140,6 @@ var Imangascans = {
         $("body", doc).css('background-color', '#f5f5f5');
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Imangascans", Imangascans);

--- a/ImperialScans.js
+++ b/ImperialScans.js
@@ -1,4 +1,4 @@
-var ImperialScans = 
+var ImperialScans =
 {
 	// Name of the mirror
 	mirrorName: "Imperial Scans",
@@ -7,13 +7,11 @@ var ImperialScans =
 	// Extension internal link to the icon of the mirror. (if not filled, will be blank...)
 	mirrorIcon: "img/imperial.png",
 	languages: "en",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("imperialscans.com") != -1);
 	},
-  
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -27,23 +25,20 @@ var ImperialScans =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
 				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('#chapters-list .manga-entry', div).each(function()
 				{
 					res.push([$('h2', $(this)).text(), 'http://imperialscans.com' + $('li:first a', $(this)).attr('href').match(/^\/read\/[^/]*/g)[0]]);
 				});
-
 				callback("Imperial Scans", res);
 			}
 		});
-	}, 
-  
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -57,28 +52,25 @@ var ImperialScans =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement( "div" ); 
+				var div = document.createElement( "div" );
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('#chapter-select option', div).each(function()
 				{
 					if ($(this).attr('value') == '') return true;
 					res.push([$(this).text(), 'http://imperialscans.com' + $(this).attr('value')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -88,16 +80,14 @@ var ImperialScans =
 		var currentChapter = hlogospan.substr(hlogospan.lastIndexOf(' ') + 1);
 		var currentMangaURL = 'http://imperialscans.com' + $('#series-select option:contains('+name+')', doc).attr('value');
 		var currentChapterURL = 'http://imperialscans.com' + $('#chapter-select option:contains('+currentChapter+')', doc).attr('value');
-
 		callback(
 		{
-			"name": name, 
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"name": name,
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL}
 		);
-	}, 
-  
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -111,7 +101,6 @@ var ImperialScans =
 		});
 		return res;
 	},
-  
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
@@ -120,14 +109,12 @@ var ImperialScans =
 		$('#side-ad', doc).remove();
 		$('#p180-root', doc).remove();
 	},
-  
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('#container .pageAMR', doc);
 	},
-  
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -136,13 +123,11 @@ var ImperialScans =
 	{
 		return $(".navAMR", doc);
 	},
-  
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return (curUrl.search('imperialscans.com/read/') > -1);
 	},
-  
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -164,7 +149,6 @@ var ImperialScans =
 		$('#nextPage', doc).remove();
 		$(".navAMR", doc).css("text-align", "center");
 	},
-  
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -178,7 +162,6 @@ var ImperialScans =
 		}
 		return null;
 	},
-  
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -192,7 +175,6 @@ var ImperialScans =
 		}
 		return null;
 	},
-  
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -202,20 +184,17 @@ var ImperialScans =
 	{
 		$.ajax(
 		{
-			url: 'http://imperialscans.com' + urlImg,         
+			url: 'http://imperialscans.com' + urlImg,
 			success: function(objResponse)
 			{
 				var div = document.createElement("div");
-				div.innerHTML = objResponse; 
-
+				div.innerHTML = objResponse;
 				var src = 'http://imperialscans.com' + $('#page-img', div).attr('src');
-
 				$(image).attr("src", src);
 			}
 		});
 	},
-  
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -223,15 +202,13 @@ var ImperialScans =
 	{
 		return false;
 	},
-  
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-  
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -239,7 +216,6 @@ var ImperialScans =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Imperial Scans", ImperialScans);

--- a/ItaScan.js
+++ b/ItaScan.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var ItaScan = {
   //Name of the mirror
   mirrorName : "ItaScan",
@@ -21,12 +19,10 @@ var ItaScan = {
   mirrorIcon : "img/itascan.png",
   //Languages of scans for the mirror
   languages : "it",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("itascan.info/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,16 +31,14 @@ var ItaScan = {
      $.ajax(
         {
           url: "http://www.itascan.info/search/",
-          type: 'POST', 
+          type: 'POST',
           data: "nomemanga=" + search,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("a", $("#newsgroup > div", div)).each(function(index) {
@@ -53,8 +47,7 @@ var ItaScan = {
             callback("ItaScan", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,16 +56,13 @@ var ItaScan = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             //console.log($($("#left-menuall .news > div", div)[1]).html());
             //console.log($("div > a", $($("#left-menuall .news > div", div)[1])).size());
@@ -80,16 +70,14 @@ var ItaScan = {
                 var team = $("a", $(this).parent().next()).text();
                 res[res.length] = [$(this).text().trim() + " (" + team + ")", "http://www.itascan.info" + $(this).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -97,23 +85,19 @@ var ItaScan = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("#contenitore span.nomemanga a", doc).text().trim();
     currentChapter = $("#contenitore .menu select option:selected", doc).text();
     currentChapterURL = "http://www.itascan.info/" + $("#contenitore .menu select option:selected", doc).val();
     currentMangaURL = "http://www.itascan.info" + $("#contenitore span.nomemanga a", doc).attr("href");
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -123,35 +107,29 @@ var ItaScan = {
     $("option", $($("select[name='task']", doc)[0])).each(function(index) {
       res[res.length] = "http://www.itascan.info/" + $(this).val();
     });
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".pubblicita", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#image", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $($(".width", doc)[2]).add($($(".width", doc)[4]));
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#wievcap", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -161,9 +139,7 @@ var ItaScan = {
     $("#image", doc).css("padding-top", "10px");
     $($(".width", doc)[2]).empty();
     $($(".width", doc)[4]).empty();
-
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -173,7 +149,6 @@ var ItaScan = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -183,7 +158,6 @@ var ItaScan = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -192,44 +166,37 @@ var ItaScan = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = "http://www.itascan.info" + $("#wievcap", div).attr("src");
-          
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#contenitore .menu select option", doc).each(function(index) {
       $(this).val("http://www.itascan.info/" + $(this).val());
     });
-    
     return $("#contenitore .menu select", doc);
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("ItaScan", ItaScan);

--- a/Japanzai.js
+++ b/Japanzai.js
@@ -160,7 +160,6 @@ var Japanzai = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Japanzai & XscansX", Japanzai);

--- a/KawaiiScans.js
+++ b/KawaiiScans.js
@@ -130,7 +130,6 @@ var KawaiiScans = {
     $("body", doc).css('background-color', '#f5f5f5');
   }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Kawaii Scans", KawaiiScans);

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,11 @@
 GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
-
  Copyright (C) 2007 Free Software Foundation, Inc. {http://fsf.org/}
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
-
                             Preamble
-
   The GNU General Public License is a free, copyleft license for
 software and other kinds of works.
-
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
 the GNU General Public License is intended to guarantee your freedom to
@@ -18,35 +14,29 @@ software for all its users.  We, the Free Software Foundation, use the
 GNU General Public License for most of our software; it applies also to
 any other work released this way by its authors.  You can apply it to
 your programs, too.
-
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
-
   To protect your rights, we need to prevent others from denying you
 these rights or asking you to surrender the rights.  Therefore, you have
 certain responsibilities if you distribute copies of the software, or if
 you modify it: responsibilities to respect the freedom of others.
-
   For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must pass on to the recipients the same
 freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
 know their rights.
-
   Developers that use the GNU GPL protect your rights with two steps:
 (1) assert copyright on the software, and (2) offer you this License
 giving you legal permission to copy, distribute and/or modify it.
-
   For the developers' and authors' protection, the GPL clearly explains
 that there is no warranty for this free software.  For both users' and
 authors' sake, the GPL requires that modified versions be marked as
 changed, so that their problems will not be attributed erroneously to
 authors of previous versions.
-
   Some devices are designed to deny users access to install or run
 modified versions of the software inside them, although the manufacturer
 can do so.  This is fundamentally incompatible with the aim of
@@ -57,49 +47,37 @@ have designed this version of the GPL to prohibit the practice for those
 products.  If such problems arise substantially in other domains, we
 stand ready to extend this provision to those domains in future versions
 of the GPL, as needed to protect the freedom of users.
-
   Finally, every program is threatened constantly by software patents.
 States should not allow patents to restrict development and use of
 software on general-purpose computers, but in those that do, we wish to
 avoid the special danger that patents applied to a free program could
 make it effectively proprietary.  To prevent this, the GPL assures that
 patents cannot be used to render the program non-free.
-
   The precise terms and conditions for copying, distribution and
 modification follow.
-
                        TERMS AND CONDITIONS
-
   0. Definitions.
-
   "This License" refers to version 3 of the GNU General Public License.
-
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
-
   "The Program" refers to any copyrightable work licensed under this
 License.  Each licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
-
   To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
 exact copy.  The resulting work is called a "modified version" of the
 earlier work or a work "based on" the earlier work.
-
   A "covered work" means either the unmodified Program or a work based
 on the Program.
-
   To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
 public, and in some countries other activities as well.
-
   To "convey" a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
 a computer network, with no transfer of a copy, is not conveying.
-
   An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
@@ -108,18 +86,14 @@ extent that warranties are provided), that licensees may convey the
 work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
-
   1. Source Code.
-
   The "source code" for a work means the preferred form of the work
 for making modifications to it.  "Object code" means any non-source
 form of a work.
-
   A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
 is widely used among developers working in that language.
-
   The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
@@ -130,7 +104,6 @@ implementation is available to the public in source code form.  A
 (kernel, window system, and so on) of the specific operating system
 (if any) on which the executable work runs, or a compiler used to
 produce the work, or an object code interpreter used to run it.
-
   The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
@@ -143,16 +116,12 @@ the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
 subprograms and other parts of the work.
-
   The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
 Source.
-
   The Corresponding Source for a work in source code form is that
 same work.
-
   2. Basic Permissions.
-
   All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
@@ -160,7 +129,6 @@ permission to run the unmodified Program.  The output from running a
 covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
 rights of fair use or other equivalent, as provided by copyright law.
-
   You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
@@ -171,19 +139,15 @@ not control copyright.  Those thus making or running the covered works
 for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
 your copyrighted material outside their relationship with you.
-
   Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
 makes it unnecessary.
-
   3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
   No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
 measures.
-
   When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
@@ -191,9 +155,7 @@ the covered work, and you disclaim any intention to limit operation or
 modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
 technological measures.
-
   4. Conveying Verbatim Copies.
-
   You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
@@ -201,24 +163,18 @@ keep intact all notices stating that this License and any
 non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
 recipients a copy of this License along with the Program.
-
   You may charge any price or no price for each copy that you convey,
 and you may offer support or warranty protection for a fee.
-
   5. Conveying Modified Source Versions.
-
   You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
 terms of section 4, provided that you also meet all of these conditions:
-
     a) The work must carry prominent notices stating that you modified
     it, and giving a relevant date.
-
     b) The work must carry prominent notices stating that it is
     released under this License and any conditions added under section
     7.  This requirement modifies the requirement in section 4 to
     "keep intact all notices".
-
     c) You must license the entire work, as a whole, under this
     License to anyone who comes into possession of a copy.  This
     License will therefore apply, along with any applicable section 7
@@ -226,12 +182,10 @@ terms of section 4, provided that you also meet all of these conditions:
     regardless of how they are packaged.  This License gives no
     permission to license the work in any other way, but it does not
     invalidate such permission if you have separately received it.
-
     d) If the work has interactive user interfaces, each must display
     Appropriate Legal Notices; however, if the Program has interactive
     interfaces that do not display Appropriate Legal Notices, your
     work need not make them do so.
-
   A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
@@ -241,19 +195,15 @@ used to limit the access or legal rights of the compilation's users
 beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
 parts of the aggregate.
-
   6. Conveying Non-Source Forms.
-
   You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
 in one of these ways:
-
     a) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by the
     Corresponding Source fixed on a durable physical medium
     customarily used for software interchange.
-
     b) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by a
     written offer, valid for at least three years and valid for as
@@ -265,13 +215,11 @@ in one of these ways:
     more than your reasonable cost of physically performing this
     conveying of source, or (2) access to copy the
     Corresponding Source from a network server at no charge.
-
     c) Convey individual copies of the object code with a copy of the
     written offer to provide the Corresponding Source.  This
     alternative is allowed only occasionally and noncommercially, and
     only if you received the object code with such an offer, in accord
     with subsection 6b.
-
     d) Convey the object code by offering access from a designated
     place (gratis or for a charge), and offer equivalent access to the
     Corresponding Source in the same way through the same place at no
@@ -284,16 +232,13 @@ in one of these ways:
     Corresponding Source.  Regardless of what server hosts the
     Corresponding Source, you remain obligated to ensure that it is
     available for as long as needed to satisfy these requirements.
-
     e) Convey the object code using peer-to-peer transmission, provided
     you inform other peers where the object code and Corresponding
     Source of the work are being offered to the general public at no
     charge under subsection 6d.
-
   A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
 included in conveying the object code work.
-
   A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
@@ -306,7 +251,6 @@ actually uses, or expects or is expected to use, the product.  A product
 is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
 the only significant mode of use of the product.
-
   "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
@@ -314,7 +258,6 @@ a modified version of its Corresponding Source.  The information must
 suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
 modification has been made.
-
   If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
@@ -325,7 +268,6 @@ by the Installation Information.  But this requirement does not apply
 if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
 been installed in ROM).
-
   The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
@@ -333,15 +275,12 @@ the User Product in which it has been modified or installed.  Access to a
 network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
 protocols for communication across the network.
-
   Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
 unpacking, reading or copying.
-
   7. Additional Terms.
-
   "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
@@ -350,41 +289,32 @@ that they are valid under applicable law.  If additional permissions
 apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
 this License without regard to the additional permissions.
-
   When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
 for which you have or can give appropriate copyright permission.
-
   Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
 that material) supplement the terms of this License with terms:
-
     a) Disclaiming warranty or limiting liability differently from the
     terms of sections 15 and 16 of this License; or
-
     b) Requiring preservation of specified reasonable legal notices or
     author attributions in that material or in the Appropriate Legal
     Notices displayed by works containing it; or
-
     c) Prohibiting misrepresentation of the origin of that material, or
     requiring that modified versions of such material be marked in
     reasonable ways as different from the original version; or
-
     d) Limiting the use for publicity purposes of names of licensors or
     authors of the material; or
-
     e) Declining to grant rights under trademark law for use of some
     trade names, trademarks, or service marks; or
-
     f) Requiring indemnification of licensors and authors of that
     material by anyone who conveys the material (or modified versions of
     it) with contractual assumptions of liability to the recipient, for
     any liability that these contractual assumptions directly impose on
     those licensors and authors.
-
   All other non-permissive additional terms are considered "further
 restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
@@ -394,46 +324,37 @@ a further restriction but permits relicensing or conveying under this
 License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
 not survive such relicensing or conveying.
-
   If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
 where to find the applicable terms.
-
   Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
 the above requirements apply either way.
-
   8. Termination.
-
   You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
 paragraph of section 11).
-
   However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
 prior to 60 days after the cessation.
-
   Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
 your receipt of the notice.
-
   Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
 material under section 10.
-
   9. Acceptance Not Required for Having Copies.
-
   You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
@@ -442,14 +363,11 @@ nothing other than this License grants you permission to propagate or
 modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
 covered work, you indicate your acceptance of this License to do so.
-
   10. Automatic Licensing of Downstream Recipients.
-
   Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
 for enforcing compliance by third parties with this License.
-
   An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
@@ -459,7 +377,6 @@ licenses to the work the party's predecessor in interest had or could
 give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
 the predecessor has it or can get it with reasonable efforts.
-
   You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
@@ -467,13 +384,10 @@ rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
 any patent claim is infringed by making, using, selling, offering for
 sale, or importing the Program or any portion of it.
-
   11. Patents.
-
   A "contributor" is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
 work thus licensed is called the contributor's "contributor version".
-
   A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
@@ -483,19 +397,16 @@ consequence of further modification of the contributor version.  For
 purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
 this License.
-
   Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
 propagate the contents of its contributor version.
-
   In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
 sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
 patent against the party.
-
   If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
@@ -509,7 +420,6 @@ actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
 country that you have reason to believe are valid.
-
   If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
@@ -517,7 +427,6 @@ receiving the covered work authorizing them to use, propagate, modify
 or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
 work and works based on it.
-
   A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
@@ -532,13 +441,10 @@ conveyed by you (or copies made from those copies), or (b) primarily
 for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
 or that patent license was granted, prior to 28 March 2007.
-
   Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
 otherwise be available to you under applicable patent law.
-
   12. No Surrender of Others' Freedom.
-
   If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
@@ -548,9 +454,7 @@ not convey it at all.  For example, if you agree to terms that obligate you
 to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
-
   13. Use with the GNU Affero General Public License.
-
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
 under version 3 of the GNU Affero General Public License into a single
@@ -559,14 +463,11 @@ License will continue to apply to the part which is the covered work,
 but the special requirements of the GNU Affero General Public License,
 section 13, concerning interaction through a network will apply to the
 combination as such.
-
   14. Revised Versions of this License.
-
   The Free Software Foundation may publish revised and/or new versions of
 the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
-
   Each version is given a distinguishing version number.  If the
 Program specifies that a certain numbered version of the GNU General
 Public License "or any later version" applies to it, you have the
@@ -575,19 +476,15 @@ version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
 GNU General Public License, you may choose any version ever published
 by the Free Software Foundation.
-
   If the Program specifies that a proxy can decide which future
 versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
-
   Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
 later version.
-
   15. Disclaimer of Warranty.
-
   THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
 HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
@@ -596,9 +493,7 @@ THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
   16. Limitation of Liability.
-
   IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
@@ -608,64 +503,48 @@ DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
 PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
-
   17. Interpretation of Sections 15 and 16.
-
   If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
-
                      END OF TERMS AND CONDITIONS
-
             How to Apply These Terms to Your New Programs
-
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
-
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
-
     {one line to give the program's name and a brief idea of what it does.}
     Copyright (C) {year}  {name of author}
-
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see {http://www.gnu.org/licenses/}.
-
 Also add information on how to contact you by electronic and paper mail.
-
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
-
     mirrors  Copyright (C) 2013  AllMangasReader-dev
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
-
 The hypothetical commands `show w' and `show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
-
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
 {http://www.gnu.org/licenses/}.
-
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with

--- a/MCReborn.js
+++ b/MCReborn.js
@@ -5,14 +5,12 @@
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////
 */
-
 //This class is an example of manga site following implementation for All Manga Reader.
 //To test this class, just modify the json variable in mgEntry.js.
-//If your implementation works and has been fully tested, send it to me with an 
+//If your implementation works and has been fully tested, send it to me with an
 //icon (png with transparency file, 16x16) for your mirror
 //at pl dot duhoux (at) gmail dot com. I will add it in the extension.
 //If you have problems implementing your mirror, send me a mail... i will be glad to help you...
-
 //CHANGE here the classname
 var MCReborn = {
   //CHANGE : Name of the mirror
@@ -22,12 +20,10 @@ var MCReborn = {
   //CHANGE : Extension internal link to the icon of the mirror. (if not filled, will be blank...)
   mirrorIcon : "img/mcreborn.png",
   languages: "en",
-
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("mcreborn.com/reader/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -42,26 +38,22 @@ var MCReborn = {
 		  {
 			'search': search
 		  },
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $('.list > .group > .title > a', div).each(function(index) {
 			  res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-
             callback("MC Reborn", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -71,38 +63,32 @@ var MCReborn = {
         {
           //CHANGE URL HERE
           url: urlManga,
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $('.list > .element > .title > a', div).each(function(index) {
               res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-            
             callback(res, obj);
           }
     });
   },
-
   /********************************************************************************************************
     IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
     However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
     of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
     the object doc (example, replace $("select") by $("select", doc) in jQuery).
   ********************************************************************************************************/
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -110,13 +96,11 @@ var MCReborn = {
     var currentChapter = $('.tbtitle div a', doc)[1].text;
     var currentMangaURL = $('.tbtitle div a', doc)[0].href;
     var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -129,18 +113,15 @@ var MCReborn = {
 	});
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     return $('#page', doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -149,12 +130,10 @@ var MCReborn = {
     //you can change the DOM of the page before this method is called in doSomethingBeforeWritingScans
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return (curUrl.search('mcreborn.com/reader/reader/read/') > -1);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
 	script = doc.createElement('script');
@@ -166,7 +145,6 @@ var MCReborn = {
     $("#page", doc).empty();
     $(".navAMR").css("text-align", "center");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -176,7 +154,6 @@ var MCReborn = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -186,7 +163,6 @@ var MCReborn = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -195,8 +171,7 @@ var MCReborn = {
     //This function runs in the DOM of the current consulted page.
     $(image).attr("src", urlImg);
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
@@ -204,26 +179,21 @@ var MCReborn = {
     //DO NOT CHANGE IF NOT NEEDED, NOT USED BY ANY EXISTING MIRROR AND CHAPTER'S DISPLAY IS WORKING FINE FOR THEM
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //RETURN A SELECT IF NEEDED, ELSE, THE EXTENSIOn WILL FIND CHAPTER BY IT'S OWN MEANS
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     //THE FOLLOWING LINE IS NECESSARY IN MOST OF CASES
     $("body > div:empty", doc).remove();
-    
     //DO ANYTHING ELSE YOU NEED
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MC Reborn", MCReborn);

--- a/Manga24.js
+++ b/Manga24.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var Manga24 = {
   //Name of the mirror
   mirrorName : "Manga24",
@@ -21,12 +19,10 @@ var Manga24 = {
   mirrorIcon : "img/Manga24.png",
   //Languages of scans for the mirror
   languages : "ru",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("manga24.ru/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var Manga24 = {
      $.ajax(
         {
           url: "http://manga24.ru/all/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("select#manga_list > option", div).each(function(index) {
@@ -53,8 +47,7 @@ var Manga24 = {
             callback("Manga24", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,16 +56,13 @@ var Manga24 = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             if ($("#main .chapters li", div).size() > 0) {
               $("#main .chapters li", div).each(
@@ -87,11 +77,10 @@ var Manga24 = {
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -103,14 +92,12 @@ var Manga24 = {
         mangaURL = "http://manga24.ru" + $(this).text().substring(pos, fin) + "/";
       }
     });
-    
     var name = $("title", doc).text();//$( $("option:selected", $("select[name='series']", doc)[0] ) ).text();
     var pos = name.indexOf("-");
     if (pos != -1) {
       name = name.substring(0, pos).trim();
     }
     var nameurl = mangaURL;
-    
     var curChapName = "";
     var chapurl = "";
     if ($("#chapters select", doc).size() > 0) {
@@ -120,13 +107,11 @@ var Manga24 = {
       curChapName = name;
       chapurl = mangaURL + "read/";
     }
-    
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -153,20 +138,17 @@ var Manga24 = {
     });
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //$("iframe", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -174,20 +156,16 @@ var Manga24 = {
     return $(".navAMR", doc);
     //return $("select[name='series']").parent().parent();
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     var isChap = false;
-    
     $("script", doc).each(function(index) {
       if ($(this).text().indexOf("Reader.init(") != -1)  {
         isChap = true;
       }
     });
-    
     return isChap;
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -198,7 +176,6 @@ var Manga24 = {
     $("<div class='scanAMR'></div>").appendTo($("#content", doc));
     $("<div class='navAMR'></div>").appendTo($("#content", doc));
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -208,7 +185,6 @@ var Manga24 = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -218,7 +194,6 @@ var Manga24 = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -227,16 +202,14 @@ var Manga24 = {
     //This function runs in the DOM of the current consulted page.
     $( image ).attr( "src", urlImg )
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -262,17 +235,14 @@ var Manga24 = {
     } else {
       select = $("<select><option val=\"" + mangaURL + "read/\" selected=\"true\">" + name + "</option></select>");
     }
-    
     return select;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //$("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga24", Manga24);

--- a/Manga2u.js
+++ b/Manga2u.js
@@ -157,7 +157,6 @@ var Manga2u = {
       $("body > div:empty", doc).remove();
    },
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga2u", Manga2u);

--- a/MangaAccess.js
+++ b/MangaAccess.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaAccess = {
   //Name of the mirror
   mirrorName : "MangaAccess",
@@ -21,12 +19,10 @@ var MangaAccess = {
   mirrorIcon : "img/mangaaccess.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("manga-access.com") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var MangaAccess = {
      $.ajax(
         {
           url: "http://manga-access.com/manga/list",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#inner_page div > a", div).each(function(index) {
@@ -51,8 +45,7 @@ var MangaAccess = {
             callback("MangaAccess", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -61,33 +54,27 @@ var MangaAccess = {
      $.ajax(
         {
           url: urlManga + "?mature_confirm=1",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
             $("#inner_page a.download-link", div).each(
                 function(index){
                     res[res.length] = [$("strong", $(this)).text(), "http://manga-access.com" + $(this).attr("href")];
                  }
             );
-            
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -95,19 +82,17 @@ var MangaAccess = {
     var curChapName = $( "#bc a:nth-child(5)", doc ).text();
     var nameurl =  "http://manga-access.com" + $( "#bc a:nth-child(4)", doc ).attr("href");
     var chapurl = "http://manga-access.com" + $( "#bc a:nth-child(5)", doc ).attr("href");
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
   getListImages : function(doc, curUrl2) {
     //This function runs in the DOM of the current consulted page.
     var res = [];
-
     $("#page_switch option", doc).each(
         function(index){
             res[index] = "http://manga-access.com" + $(this).val();
@@ -115,21 +100,18 @@ var MangaAccess = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#pic", doc).prev().remove();
     $("#pic", doc).next().next().remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#pic", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -137,12 +119,10 @@ var MangaAccess = {
     return $("#bc", doc).add($(".navAMR", doc));
     //return $("select[name='series']").parent().parent();
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#pic img", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -155,7 +135,6 @@ var MangaAccess = {
     $(".navAMR", doc).css("text-align", "center");
     $("#bc", doc).css("text-align", "center");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -165,7 +144,6 @@ var MangaAccess = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -175,7 +153,6 @@ var MangaAccess = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -187,24 +164,20 @@ var MangaAccess = {
           url: urlImg,
           success: function( objResponse ){
             var div = document.createElement( "div" );
-            div.innerHTML = objResponse; 
-      
-            var src = $("#pic img", div).attr("src"); 
-        
+            div.innerHTML = objResponse;
+            var src = $("#pic img", div).attr("src");
             $( image ).attr( "src", src );
           }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -213,14 +186,12 @@ var MangaAccess = {
     });
     return $("#chapter_switch", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaAccess", MangaAccess);

--- a/MangaAr.js
+++ b/MangaAr.js
@@ -134,7 +134,6 @@ var MangaAr = {
       $("body > div:empty", doc).remove();
    }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Ar", MangaAr);

--- a/MangaChapter.js
+++ b/MangaChapter.js
@@ -1,4 +1,4 @@
-var MangaChapter = 
+var MangaChapter =
 {
     mirrorName: "MangaChapter",
     canListFullMangas: false,
@@ -21,13 +21,13 @@ var MangaChapter =
                 {
                     xhr.setRequestHeader("Cache-Control", "no-cache");
                     xhr.setRequestHeader("Pragma", "no-cache");
-                }, 
+                },
                 success: function(response)
                 {
                     var div = document.createElement('div');
                     div.innerHTML = response.replace('<img ', '<noload ');
                     $(".info_box a", div).each(function(index)
-                    {   
+                    {
                         res[res.length] = [$(this).text(), $(this).attr("href") || ""];
                     });
                     var next = false;
@@ -48,7 +48,7 @@ var MangaChapter =
             });
         };
         getMangaListRecursive(urlSearch, callback);
-    }, 
+    },
     getListChaps: function(urlManga, mangaName, obj, callback)
     {
         var res = [];
@@ -61,10 +61,10 @@ var MangaChapter =
                 {
                     xhr.setRequestHeader("Cache-Control", "no-cache");
                     xhr.setRequestHeader("Pragma", "no-cache");
-                }, 
+                },
                 success: function(response)
                 {
-                    var div = document.createElement( "div" ); 
+                    var div = document.createElement( "div" );
                     div.innerHTML = response.replace('<img ', '<noload ');
                     $(".mangadata a[title]", div).each(function(index)
                     {
@@ -98,9 +98,9 @@ var MangaChapter =
         currentChapter = currentChapter.replace(name, "");
         callback(
         {
-            "name": name.trim(), 
-            "currentChapter": currentChapter.trim(), 
-            "currentMangaURL": mangaurl.trim(), 
+            "name": name.trim(),
+            "currentChapter": currentChapter.trim(),
+            "currentMangaURL": mangaurl.trim(),
             "currentChapterURL": curUrl
         });
     },
@@ -168,7 +168,7 @@ var MangaChapter =
             success: function(objResponse)
             {
                 var div = document.createElement( "div" );
-                div.innerHTML = objResponse; 
+                div.innerHTML = objResponse;
                 var src = $("#mangaImg, #Img1", div).attr("src") || "";
                 $( image ).attr( "src", src);
             }
@@ -202,7 +202,6 @@ var MangaChapter =
         }
     }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaChapter", MangaChapter);

--- a/MangaEden_en.js
+++ b/MangaEden_en.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaEden_en = {
   //Name of the mirror
   mirrorName : "Manga Eden (EN)",
@@ -21,21 +19,18 @@ var MangaEden_en = {
   mirrorIcon : "img/mangaeden.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("www.mangaeden.com/en-manga/") != -1);
   },
-  
   getMangaListPage: function(response, res)
   {
-      var div = document.createElement("div");  
+      var div = document.createElement("div");
 	  div.innerHTML = response;
 	  $('#mangaList tr td:first-child a', div).each(function(index) {
 	    res.push([$(this).text(), "http://www.mangaeden.com" + $(this).attr("href")]);
 	  });
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -44,16 +39,14 @@ var MangaEden_en = {
      $.ajax(
         {
           url: "http://www.mangaeden.com/en-directory/?title=" + search,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
 			res = [];
 			MangaEden_en.getMangaListPage(objResponse, res);
-			var div = document.createElement("div");  
+			var div = document.createElement("div");
 		    div.innerHTML = objResponse;
 			if (!isNaN(n = parseInt($('.pagination_bottom a:not(:has(span)):last', div).text())))
 			{
@@ -77,8 +70,7 @@ var MangaEden_en = {
             callback("Manga Eden (EN)", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -87,31 +79,25 @@ var MangaEden_en = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $('.chapterLink', div).each(function(index) {
                 res[res.length] = [parseFloat($("b", $(this)).text()), "http://www.mangaeden.com" + $(this).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -119,13 +105,11 @@ var MangaEden_en = {
     var currentChapter = $('#combobox option:selected', doc).text();
     var currentMangaURL = "http://www.mangaeden.com" + $('#top a:last', doc).attr('href');
     var currentChapterURL = currentMangaURL + currentChapter + "/1/";
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -137,10 +121,8 @@ var MangaEden_en = {
 	{
 		res.push($(this).attr('href'));
     });
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -148,21 +130,18 @@ var MangaEden_en = {
     $("#adsRight", doc).remove();
     $("#bottomAds", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     if (curUrl.indexOf("www.mangaeden.com/en-manga/") != -1)
@@ -170,11 +149,9 @@ var MangaEden_en = {
 		return (curUrl.substring(curUrl.indexOf("www.mangaeden.com/en-manga/") + 27).split(/\//g).length - 1) > 1
 	}
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
 	$('.pagination').remove();
     $("#content", doc).empty();
     $("<div class='navAMR'></div>").appendTo($("#content", doc));
@@ -185,7 +162,6 @@ var MangaEden_en = {
 	script.innerText = "document.onkeydown = null;\n";
 	doc.body.appendChild(script);
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -195,7 +171,6 @@ var MangaEden_en = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -205,7 +180,6 @@ var MangaEden_en = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -222,33 +196,28 @@ var MangaEden_en = {
 		{
 			var div = document.createElement( "div" );
 			div.innerHTML = objResponse;
-
 			$(image).attr('src', $('#mainImgC img', div).attr('src'));
 		}
 	});
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     return null;
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Eden (EN)", MangaEden_en);

--- a/MangaEden_it.js
+++ b/MangaEden_it.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaEden_it = {
   //Name of the mirror
   mirrorName : "Manga Eden (IT)",
@@ -21,21 +19,18 @@ var MangaEden_it = {
   mirrorIcon : "img/mangaeden.png",
   //Languages of scans for the mirror
   languages : "it",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("www.mangaeden.com/it-manga/") != -1);
   },
-  
   getMangaListPage: function(response, res)
   {
-      var div = document.createElement("div");  
+      var div = document.createElement("div");
 	  div.innerHTML = response;
 	  $('#mangaList tr td:first-child a', div).each(function(index) {
 	    res.push([$(this).text(), "http://www.mangaeden.com" + $(this).attr("href")]);
 	  });
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -44,16 +39,14 @@ var MangaEden_it = {
      $.ajax(
         {
           url: "http://www.mangaeden.com/it-directory/?title=" + search,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
 			res = [];
 			MangaEden_it.getMangaListPage(objResponse, res);
-			var div = document.createElement("div");  
+			var div = document.createElement("div");
 		    div.innerHTML = objResponse;
 			if (!isNaN(n = parseInt($('.pagination_bottom a:not(:has(span)):last', div).text())))
 			{
@@ -77,8 +70,7 @@ var MangaEden_it = {
             callback("Manga Eden (IT)", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -87,31 +79,25 @@ var MangaEden_it = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $('.chapterLink', div).each(function(index) {
                 res[res.length] = [parseFloat($("b", $(this)).text()), "http://www.mangaeden.com" + $(this).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -119,13 +105,11 @@ var MangaEden_it = {
     var currentChapter = $('#combobox option:selected', doc).text();
     var currentMangaURL = "http://www.mangaeden.com" + $('#top a:last', doc).attr('href');
     var currentChapterURL = currentMangaURL + currentChapter + "/1/";
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -137,10 +121,8 @@ var MangaEden_it = {
 	{
 		res.push($(this).attr('href'));
     });
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -148,21 +130,18 @@ var MangaEden_it = {
     $("#adsRight", doc).remove();
     $("#bottomAds", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     if (curUrl.indexOf("www.mangaeden.com/it-manga/") != -1)
@@ -170,11 +149,9 @@ var MangaEden_it = {
 		return (curUrl.substring(curUrl.indexOf("www.mangaeden.com/it-manga/") + 27).split(/\//g).length - 1) > 1
 	}
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
 	$('.pagination').remove();
     $("#content", doc).empty();
     $("<div class='navAMR'></div>").appendTo($("#content", doc));
@@ -185,7 +162,6 @@ var MangaEden_it = {
 	script.innerText = "document.onkeydown = null;\n";
 	doc.body.appendChild(script);
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -195,7 +171,6 @@ var MangaEden_it = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -205,7 +180,6 @@ var MangaEden_it = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -222,33 +196,28 @@ var MangaEden_it = {
 		{
 			var div = document.createElement( "div" );
 			div.innerHTML = objResponse;
-
 			$(image).attr('src', $('#mainImgC img', div).attr('src'));
 		}
 	});
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     return null;
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Eden (IT)", MangaEden_it);

--- a/MangaExceed.js
+++ b/MangaExceed.js
@@ -3,7 +3,6 @@ var MangaExceed={mirrorName:"Manga Exceed",canListFullMangas:false,mirrorIcon:"i
 return null;},previousChapterUrl:function(select,doc,curUrl){if($(select).children("option:selected").next().size()!=0){return $(select).children("option:selected").next().val();}
 return null;},getImageFromPageAndWrite:function(urlImg,image,doc,curUrl){$.ajax({url:urlImg,success:function(objResponse)
 {var div=document.createElement("div");div.innerHTML=objResponse;$(image).attr('src',$('#contentInner3 img',div).attr('src'));}});},isImageInOneCol:function(img,doc,curUrl){return false;},getMangaSelectFromPage:function(doc,curUrl){return null;},doAfterMangaLoaded:function(doc,curUrl){$("body > div:empty",doc).remove();}}
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Exceed", MangaExceed);

--- a/MangaFox.js
+++ b/MangaFox.js
@@ -97,7 +97,7 @@ var MangaFox = {
         "use strict";
         var str = $('#series > strong a', doc).text(); // dom lookups are expensive!
         var name = $('#related > h3 a', doc).text() || str.substring(0,
-            str.length - 6); //falls through #related, into #series 
+            str.length - 6); //falls through #related, into #series
         var currentChapter = $("#series h1", doc).text();
         var url = curUrl;
         var posSl5 = 0;
@@ -209,7 +209,6 @@ var MangaFox = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga-Fox", MangaFox);

--- a/MangaFox.js
+++ b/MangaFox.js
@@ -20,7 +20,7 @@ var MangaFox = {
             },
             success: function(objResponse) {
                 var div = document.createElement("div");
-                div.innerHTML = objResponse;
+                div.innerHTML = objResponse.replace(/<img/gi, '<noload');
                 if (objResponse.indexOf("No Manga Series") !==
                     -1) {
                     callback("Manga-Fox", []);

--- a/MangaFox.js
+++ b/MangaFox.js
@@ -189,9 +189,7 @@ var MangaFox = {
             success: function(objResponse) {
                 var div = document.createElement("div");
                 div.innerHTML = objResponse;
-                var src = $("meta[property='og:image']",
-                    div).attr("content").replace(
-                    "thumbnails/mini.", "compressed/");
+                var src = $('#image').attr('src') || $("meta[property='og:image']", div).attr("content").replace("thumbnails/mini.", "compressed/");
                 $(image).attr("src", src);
             }
         });

--- a/MangaHead_en.js
+++ b/MangaHead_en.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaHead_en = {
   //Name of the mirror
   mirrorName : "MangaHead (EN)",
@@ -21,7 +19,6 @@ var MangaHead_en = {
   mirrorIcon : "img/mangahead.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
 	if ((url.indexOf("http://mangahead.com/Manga-English-Scan/") != -1) || (url.indexOf("http://mangahead.com/index.php/Manga-English-Scan/") != -1))
@@ -30,7 +27,6 @@ var MangaHead_en = {
 	}
 	return false;
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -39,14 +35,12 @@ var MangaHead_en = {
      $.ajax(
         {
           url: "http://mangahead.com/Manga-English-Scan/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#updates strong a", div).each(function(index) {
@@ -55,8 +49,7 @@ var MangaHead_en = {
             callback("MangaHead (EN)", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -65,32 +58,26 @@ var MangaHead_en = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $("#main_content strong+a", div).each(function(index) {
                 res[res.length] = [$(this).text(), "http://mangahead.com" + $(this).attr("href")];
               });
-
 			res.reverse();
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -98,13 +85,11 @@ var MangaHead_en = {
     var currentChapter = $($(".mangaviewer_toppest_navig", doc)[0].lastChild).text().trim().substring(3)
     var currentMangaURL = "http://mangahead.com" + $($(".mangaviewer_toppest_navig a", doc)[2]).attr('href');
     var currentChapterURL = currentMangaURL + "/" + currentChapter.replace(/ /g, "-");
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -133,14 +118,12 @@ var MangaHead_en = {
 					{
 						res.push("http://mangahead.com" + $(this).attr('href'));
 					});
-				}				
+				}
 			});
 		});
 	}
-	
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -148,30 +131,25 @@ var MangaHead_en = {
 	$("#bottom_ads", doc).remove();
 	$("#main_skybanner", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($(".mangahead_thumbnail_cell", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     $("#main_content", doc).empty()
     var cloned = $("#main_content", doc).clone();
     $("#main_content", doc).after(cloned);
@@ -193,7 +171,6 @@ var MangaHead_en = {
     	doc.body.appendChild(script);
   	}
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -203,7 +180,6 @@ var MangaHead_en = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -213,7 +189,6 @@ var MangaHead_en = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -222,40 +197,34 @@ var MangaHead_en = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement("div");
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("#mangahead_image", div).attr("src");
-          
           $(image).attr("src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return null;
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaHead (EN)", MangaHead_en);

--- a/MangaHead_raw.js
+++ b/MangaHead_raw.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaHead_raw = {
   //Name of the mirror
   mirrorName : "MangaHead (RAW)",
@@ -21,7 +19,6 @@ var MangaHead_raw = {
   mirrorIcon : "img/mangahead.png",
   //Languages of scans for the mirror
   languages : "ja",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
 	if ((url.indexOf("http://mangahead.com/Manga-Raw-Scan/") != -1) || (url.indexOf("http://mangahead.com/index.php/Manga-Raw-Scan/") != -1))
@@ -30,7 +27,6 @@ var MangaHead_raw = {
 	}
 	return false;
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -39,14 +35,12 @@ var MangaHead_raw = {
      $.ajax(
         {
           url: "http://mangahead.com/Manga-Raw-Scan/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#updates strong a", div).each(function(index) {
@@ -55,8 +49,7 @@ var MangaHead_raw = {
             callback("MangaHead (RAW)", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -65,32 +58,26 @@ var MangaHead_raw = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $("#main_content strong+a", div).each(function(index) {
                 res[res.length] = [$(this).text(), "http://mangahead.com" + $(this).attr("href")];
               });
-
 			res.reverse();
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -98,13 +85,11 @@ var MangaHead_raw = {
     var currentChapter = $($(".mangaviewer_toppest_navig", doc)[0].lastChild).text().trim().substring(3)
     var currentMangaURL = "http://mangahead.com" + $($(".mangaviewer_toppest_navig a", doc)[2]).attr('href');
     var currentChapterURL = currentMangaURL + "/" + currentChapter.replace(/ /g, "-");
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -133,14 +118,12 @@ var MangaHead_raw = {
 					{
 						res.push("http://mangahead.com" + $(this).attr('href'));
 					});
-				}				
+				}
 			});
 		});
 	}
-	
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -148,30 +131,25 @@ var MangaHead_raw = {
 	$("#bottom_ads", doc).remove();
 	$("#main_skybanner", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($(".mangahead_thumbnail_cell", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     $("#main_content", doc).empty()
     var cloned = $("#main_content", doc).clone();
     $("#main_content", doc).after(cloned);
@@ -193,7 +171,6 @@ var MangaHead_raw = {
     	doc.body.appendChild(script);
   	}
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -203,7 +180,6 @@ var MangaHead_raw = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -213,7 +189,6 @@ var MangaHead_raw = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -222,40 +197,34 @@ var MangaHead_raw = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement("div");
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("#mangahead_image", div).attr("src");
-          
           $(image).attr("src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return null;
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaHead (RAW)", MangaHead_raw);

--- a/MangaHere.js
+++ b/MangaHere.js
@@ -7,12 +7,10 @@ var MangaHere = {
     mirrorIcon: "img/mangahere.png",
     //Languages of scans for the mirror
     languages: "en",
-
     //Return true if the url corresponds to the mirror
     isMe: function (url) {
         return (url.indexOf("mangahere.co/") != -1);
     },
-
     //Return the list of all or part of all mangas from the mirror
     //The search parameter is filled if canListFullMangas is false
     //This list must be an Array of [["manga name", "url"], ...]
@@ -20,12 +18,10 @@ var MangaHere = {
     getMangaList: function (search, callback) {
         $.ajax({
             url: "http://www.mangahere.co/search.php?name=" + search,
-
             beforeSend: function (xhr) {
                 xhr.setRequestHeader("Cache-Control", "no-cache");
                 xhr.setRequestHeader("Pragma", "no-cache");
             },
-
             success: function (objResponse) {
                 var div = document.createElement("div");
                 div.innerHTML = objResponse;
@@ -37,7 +33,6 @@ var MangaHere = {
             }
         });
     },
-
     //Find the list of all chapters of the manga represented by the urlManga parameter
     //This list must be an Array of [["chapter name", "url"], ...]
     //This list must be sorted descending. The first element must be the most recent.
@@ -45,31 +40,25 @@ var MangaHere = {
     getListChaps: function (urlManga, mangaName, obj, callback) {
         $.ajax({
             url: urlManga,
-
             beforeSend: function (xhr) {
                 xhr.setRequestHeader("Cache-Control", "no-cache");
                 xhr.setRequestHeader("Pragma", "no-cache");
             },
-
             success: function (objResponse) {
                 var div = document.createElement("div");
                 div.innerHTML = objResponse;
-
                 var res = [];
-
                 $(".detail_list ul li span.left a", div).each(function (index) {
                     res[res.length] = [$(this).text().trim(), $(this).attr("href")];
                 });
-
                 callback(res, obj);
             }
         });
     },
-
-    //This method must return (throught callback method) an object like : 
-    //{"name" : Name of current manga, 
-    //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-    //  "currentMangaURL": Url to access current manga, 
+    //This method must return (throught callback method) an object like :
+    //{"name" : Name of current manga,
+    //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+    //  "currentMangaURL": Url to access current manga,
     //  "currentChapterURL": Url to access current chapter}
     getInformationsFromCurrentPage: function (doc, curUrl, callback) {
         //This function runs in the DOM of the current consulted page.
@@ -77,7 +66,6 @@ var MangaHere = {
         var currentChapter;
         var currentMangaURL;
         var currentChapterURL;
-
         name = $($(".readpage_top .title a", doc)[1]).text().trim();
         if (name.length >= 5 && name.substr(name.length - 5, 5) == "Manga") {
             name = name.substr(0, name.length - 5).trim();
@@ -86,8 +74,6 @@ var MangaHere = {
         currentChapterURL = $($(".readpage_top .title a", doc)[0]).attr("href");
 		console.log(currentChapterURL);
         currentMangaURL = $($(".readpage_top .title a", doc)[1]).attr("href");
-		
-		
         callback({
             "name": name,
             "currentChapter": currentChapter,
@@ -95,7 +81,6 @@ var MangaHere = {
             "currentChapterURL": currentChapterURL
         });
     },
-
     //Returns the list of the urls of the images of the full chapter
     //This function can return urls which are not the source of the
     //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -105,10 +90,8 @@ var MangaHere = {
         $("select.wid60:first option", doc).each(function (index) {
             res[res.length] = $(this).val();
         });
-
         return res;
     },
-
     //Remove the banners from the current page
     removeBanners: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
@@ -116,26 +99,22 @@ var MangaHere = {
         $("#link_heading_banner", doc).remove();
         $(".readpage_top .title", doc).next().remove();
     },
-
     //This method returns the place to write the full chapter in the document
     //The returned element will be totally emptied.
     whereDoIWriteScans: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
         return $(".scanAMR", doc);
     },
-
     //This method returns places to write the navigation bar in the document
     //The returned elements won't be emptied.
     whereDoIWriteNavigation: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
         return $(".navAMR", doc);
     },
-
     //Return true if the current page is a page containing scan.
     isCurrentPageAChapterPage: function (doc, curUrl) {
         return ($("#image", doc).size() > 0);
     },
-
     //This method is called before displaying full chapters in the page
     doSomethingBeforeWritingScans: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
@@ -145,7 +124,6 @@ var MangaHere = {
         $("<div class='scanAMR widepage'></div>").appendTo($(".amrcontainer", doc));
         $("<div class='navAMR widepage'></div>").appendTo($(".amrcontainer", doc));
     },
-
     //This method is called to fill the next button's url in the manga site navigation bar
     //The select containing the mangas list next to the button is passed in argument
     nextChapterUrl: function (select, doc, curUrl) {
@@ -155,7 +133,6 @@ var MangaHere = {
         }
         return null;
     },
-
     //This method is called to fill the previous button's url in the manga site navigation bar
     //The select containing the mangas list next to the button is passed in argument
     previousChapterUrl: function (select, doc, curUrl) {
@@ -165,7 +142,6 @@ var MangaHere = {
         }
         return null;
     },
-
     //Write the image from the the url returned by the getListImages() function.
     //The function getListImages can return an url which is not the source of the
     //image. The src of the image is set by this function.
@@ -182,22 +158,19 @@ var MangaHere = {
             }
         });
     },
-
-    //If it is possible to know if an image is a credit page or something which 
+    //If it is possible to know if an image is a credit page or something which
     //must not be displayed as a book, just return true and the image will stand alone
     //img is the DOM object of the image
     isImageInOneCol: function (img, doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
         return false;
     },
-
-    //This function can return a preexisting select from the page to fill the 
+    //This function can return a preexisting select from the page to fill the
     //chapter select of the navigation bar. It avoids to load the chapters
     getMangaSelectFromPage: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
         return null;
     },
-
     //This function is called when the manga is full loaded. Just do what you want here...
     doAfterMangaLoaded: function (doc, curUrl) {
         //This function runs in the DOM of the current consulted page.
@@ -208,7 +181,6 @@ var MangaHere = {
 		$(".spanForImg").css("text-align", "left");
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Here", MangaHere);

--- a/MangaIR.js
+++ b/MangaIR.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //    Sepehr Raftari                                                                       //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaIR = {
   //Name of the mirror
   mirrorName : "MangaIR",
@@ -21,12 +19,10 @@ var MangaIR = {
   mirrorIcon : "img/mangafarsi.PNG",
   //Languages of scans for the mirror
   languages : "fa",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("www.manga.ir/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var MangaIR = {
      $.ajax(
         {
           url: "http://www.manga.ir/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("select[name='manga'] option", div).each(function(index) {
@@ -53,8 +47,7 @@ var MangaIR = {
             callback("MangaIR", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,32 +56,27 @@ var MangaIR = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             var currentMangaURL = "http://www.manga.ir/" + $("select[name='manga']:first option:selected", div).val();
             $("select[name='chapter']:first option", div).each(function(index) {
               res[res.length] = [$(this).text(), currentMangaURL + "/" + $(this).val()];
             });
             res.reverse();
-            
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -96,24 +84,19 @@ var MangaIR = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("select[name='manga']:first option:selected", doc).text();
     currentMangaURL = "http://www.manga.ir/" + $("select[name='manga']:first option:selected", doc).val();
-    
     currentChapter = $("select[name='chapter']:first option:selected", doc).text();
     currentChapterURL = currentMangaURL + "/" + $("select[name='chapter']:first option:selected", doc).val();
-
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -122,39 +105,32 @@ var MangaIR = {
     var res = [];
     var currentMangaURL = "http://www.manga.ir/" + $("select[name='manga']:first option:selected", doc).val();
     var currentChapterURL = currentMangaURL + "/" + $("select[name='chapter']:first option:selected", doc).val();
-
     $("select[name='page']:first option", doc).each(function(index) {
       res[res.length] = currentChapterURL + "/" + $(this).val();
     });
-
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".ads", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("img.picture", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -162,13 +138,10 @@ var MangaIR = {
     $("<div class='navAMR'></div>").appendTo($("td.mid", doc));
     $("<div class='scansAMR'></div>").appendTo($("td.mid", doc));
     $("<div class='navAMR'></div>").appendTo($("td.mid", doc));
-
     $(".scansAMR", doc).css("background-color", "black");
     $(".scansAMR", doc).css("padding-top", "10px");
     $(".navAMR", doc).css("text-align", "center");
-
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -178,7 +151,6 @@ var MangaIR = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -188,7 +160,6 @@ var MangaIR = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -198,24 +169,21 @@ var MangaIR = {
   	$.ajax({
   		url: urlImg,
   		success: function( objResponse ){
-  			var div = document.createElement( "div" );  
+  			var div = document.createElement( "div" );
   			div.innerHTML = objResponse;
-  
   			var src = "http://www.manga.ir/" + $("img.picture", div).attr("src");
   			$( image ).attr( "src", src);
   		}
   	});
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -224,17 +192,14 @@ var MangaIR = {
     $("select[name='chapter']:first option", doc).each(function(index) {
       $(this).val(currentMangaURL + "/" + $(this).val());
     });
-    
     return $("select[name='chapter']:first", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaIR", MangaIR);

--- a/MangaInn.js
+++ b/MangaInn.js
@@ -133,7 +133,6 @@ var MangaInn = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaInn", MangaInn);

--- a/MangaKong.js
+++ b/MangaKong.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaKong = {
   //Name of the mirror
   mirrorName : "MangaKong",
@@ -21,12 +19,10 @@ var MangaKong = {
   mirrorIcon : "img/mangakong.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("mangakong.com") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var MangaKong = {
      $.ajax(
         {
           url: "http://www.mangakong.com/manga/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("select[name='manga'] > option", div).each(function(index) {
@@ -53,8 +47,7 @@ var MangaKong = {
             callback("MangaKong", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,34 +56,28 @@ var MangaKong = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             var nameurl = $( $("option:selected", $("select[name='manga']", div)[0] )).val();
-            
             $( $("option", $("select[name='chapter']", div)[0] ) ).each(
                 function(index){
                     res[res.length] = [$(this).text(), "http://www.mangakong.com/manga/" + nameurl + "/" + $(this).val()];
                  }
             );
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -98,22 +85,19 @@ var MangaKong = {
     var curChapName = $( $("option:selected", $("select[name='chapter']", doc)[0] ) ).text();
     var nameurl = "http://www.mangakong.com/manga/" + $( $("option:selected", $("select[name='manga']", doc)[0] ) ).val();
     var chapurl = nameurl + "/" + $( $("option:selected", $("select[name='chapter']", doc)[0] ) ).val();
-    callback({"name": name, 
-            "currentChapter": curChapName, 
-            "currentMangaURL": nameurl, 
+    callback({"name": name,
+            "currentChapter": curChapName,
+            "currentMangaURL": nameurl,
             "currentChapterURL": chapurl});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
   getListImages : function(doc, curUrl2) {
     //This function runs in the DOM of the current consulted page.
     var res = [];
-    
     var nameurl = "http://www.mangakong.com/manga/" + $( $("option:selected", $("select[name='manga']", doc)[0] ) ).val();
     var chapurl = nameurl + "/" + $( $("option:selected", $("select[name='chapter']", doc)[0] ) ).val();
-    
     $( $("option", $("select[name='page']", doc)[0] ) ).each(
         function(index){
             res[index] = chapurl + "/" + $(this).val();
@@ -121,32 +105,27 @@ var MangaKong = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("object", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#omv", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#omv .mid img.picture", doc).size() != 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -155,7 +134,6 @@ var MangaKong = {
     $("#omv", doc).empty();
     $(".navAMR").css("text-align", "center");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -165,7 +143,6 @@ var MangaKong = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -175,7 +152,6 @@ var MangaKong = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -187,23 +163,20 @@ var MangaKong = {
           url: urlImg,
           success: function( objResponse ){
             var div = document.createElement( "div" );
-            div.innerHTML = objResponse; 
-      
-            var src = "http://www.mangakong.com/manga/" + $("#omv .mid img.picture", div).attr("src"); 
+            div.innerHTML = objResponse;
+            var src = "http://www.mangakong.com/manga/" + $("#omv .mid img.picture", div).attr("src");
             $( image ).attr( "src", src );
           }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -213,14 +186,12 @@ var MangaKong = {
     });
     return $("select[name='chapter']", doc)[0];
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaKong", MangaKong);

--- a/MangaLib.js
+++ b/MangaLib.js
@@ -136,7 +136,6 @@ var MangaLib = {
     $(".reader_page_holder .AMRtable tr td", doc).css("background-color", "black");
   }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Library", MangaLib);

--- a/MangaPirate.js
+++ b/MangaPirate.js
@@ -125,7 +125,6 @@ var MangaPirate = {
     $("body > div:empty", doc).remove();
   }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Pirate", MangaPirate);

--- a/MangaReader.js
+++ b/MangaReader.js
@@ -123,7 +123,6 @@ var MangaReader = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Reader", MangaReader);

--- a/MangaStream.js
+++ b/MangaStream.js
@@ -143,7 +143,6 @@ var MangaStream = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaStream", MangaStream);

--- a/MangaTraders.js
+++ b/MangaTraders.js
@@ -4,13 +4,11 @@ var MangaTraders =
 	canListFullMangas: false,
 	mirrorIcon: "img/mangatraders.png",
 	languages: "en",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("www.mangatraders.com/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -24,10 +22,10 @@ var MangaTraders =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				//var div = document.createElement("div");  
+				//var div = document.createElement("div");
 				//div.innerHTML = objResponse;
 				var res = [];
 				$(".list1 li:not(:has(img[alt='NO_DL!'])) a", objResponse).each(function(index)
@@ -37,8 +35,7 @@ var MangaTraders =
 				callback("Manga Traders", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -52,7 +49,7 @@ var MangaTraders =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(xml)
 			{
 				var res = [];
@@ -61,16 +58,14 @@ var MangaTraders =
 					res.push([$('file_disp', this).text(), "http://www.mangatraders.com/view/list/" + $(this).attr('id')]);
 				});
 				res.reverse();
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -89,16 +84,14 @@ var MangaTraders =
 			var currentMangaURL = "http://www.mangatraders.com" + $($('#viewerHeader a')[0]).attr('href');
 			var currentChapterURL = curUrl.substring(0, curUrl.lastIndexOf('/page')==-1?curUrl.lenght:curUrl.lastIndexOf('/page')).replace('file', 'list');
 		}
-
 		callback(
 		{
-			"name": name, 
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"name": name,
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -121,10 +114,8 @@ var MangaTraders =
 				res.push(baseUrl + $(this).attr('value'));
 			});
 		}
-
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
@@ -135,7 +126,6 @@ var MangaTraders =
 		$('#google_ad_top', doc).remove();
 		$('object', doc).remove();
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -143,7 +133,6 @@ var MangaTraders =
 	{
 		return $(".scanAMR", doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -151,13 +140,11 @@ var MangaTraders =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return (curUrl.match(/www.mangatraders.com\/view\/(list|file)/gi) != null)
 	},
-
 	//This method is called before displaying full chapters in the page
 	//This function runs in the DOM of the current consulted page.
 	doSomethingBeforeWritingScans: function(doc, curUrl)
@@ -187,7 +174,6 @@ var MangaTraders =
 		$("<div class='navAMR'></div>").appendTo($("#content", doc));
 		$(".navAMR", doc).css("text-align", "center");
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -199,7 +185,6 @@ var MangaTraders =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -211,7 +196,6 @@ var MangaTraders =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -225,13 +209,11 @@ var MangaTraders =
 			{
 				//var div = document.createElement("div");
 				//div.innerHTML = objResponse;
-
 				$(image).attr('src', $('#image', objResponse).attr('src'));
 			}
 		});
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -239,14 +221,12 @@ var MangaTraders =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
-	},  
-
+	},
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded : function(doc, curUrl)
@@ -254,7 +234,6 @@ var MangaTraders =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Traders", MangaTraders);

--- a/MangaTurk.js
+++ b/MangaTurk.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var MangaTurk = {
   //Name of the mirror
   mirrorName : "MangaTurk",
@@ -21,12 +19,10 @@ var MangaTurk = {
   mirrorIcon : "img/mangaturk.png",
   //Languages of scans for the mirror
   languages : "tr",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("turkcraft.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var MangaTurk = {
      $.ajax(
         {
           url: "http://www.turkcraft.com/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("select[name='manga'] option", div).each(function(index) {
@@ -53,8 +47,7 @@ var MangaTurk = {
             callback("MangaTurk", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,31 +56,25 @@ var MangaTurk = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $("select[name='chapter']:first option", div).each(function(index) {
                 res[res.length] = [$(this).text(), urlManga + "/" + $(this).val()];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -95,24 +82,19 @@ var MangaTurk = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("select[name='manga']:first option:selected", doc).text();
     currentMangaURL = "http://www.turkcraft.com/" + $("select[name='manga']:first option:selected", doc).val();
-    
     currentChapter = $("select[name='chapter']:first option:selected", doc).text();
     currentChapterURL = currentMangaURL + "/" + $("select[name='chapter']:first option:selected", doc).val();
-
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -121,46 +103,38 @@ var MangaTurk = {
     var res = [];
     var mg = "http://www.turkcraft.com/" + $("select[name='manga']:first option:selected", doc).val();
     var chap = mg + "/" + $("select[name='chapter']:first option:selected", doc).val();
-
     $("select[name='page']:first option", doc).each(function(index) {
       res[res.length] = chap + "/" + $(this).val();
     });
-
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("iframe", doc).parents("ins").remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".pager", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("img.picture", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".pager", doc).empty();
     $("img.picture", doc).closest("td").html("<div class='scansAMR'></div>");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -170,7 +144,6 @@ var MangaTurk = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -180,7 +153,6 @@ var MangaTurk = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -190,43 +162,37 @@ var MangaTurk = {
   	$.ajax({
   		url: urlImg,
   		success: function( objResponse ){
-  			var div = document.createElement( "div" );  
+  			var div = document.createElement( "div" );
   			div.innerHTML = objResponse;
         var src = "http://www.turkcraft.com/" + $("img.picture", div).attr("src");
   			$( image ).attr( "src", src);
   		}
   	});
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     var res = [];
     var mg = "http://www.turkcraft.com/" + $("select[name='manga']:first option:selected", doc).val();
-    
     $("select[name='chapter']:first option", doc).each(function(index) {
       $(this).val(mg + "/" + $(this).val());
     });
-    
     return $("select[name='chapter']:first", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaTurk", MangaTurk);

--- a/MangaYobai.js
+++ b/MangaYobai.js
@@ -3,11 +3,9 @@ var MangaYobai = {
   canListFullMangas : false,
   mirrorIcon : "img/generic.png",
   languages: "en",
-
   isMe : function(url) {
     return (url.indexOf("mangayobai.net/foolslide") != -1);
   },
-  
   getMangaList : function(search, callback) {
      $.ajax(
         {
@@ -17,61 +15,50 @@ var MangaYobai = {
 		  {
 			'search': search
 		  },
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $('.list.series > .group > .title > a', div).each(function(index) {
 			  res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-
             callback("MangaYobai", res);
           }
     });
-  }, 
-  
+  },
   getListChaps : function(urlManga, mangaName, obj, callback) {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $('.list > .element > .title > a', div).each(function(index) {
               res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-            
             callback(res, obj);
           }
     });
   },
-
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     var name = $('.tbtitle div a', doc)[0].title;
     var currentChapter = $('.tbtitle div a', doc)[1].text;
     var currentMangaURL = $('.tbtitle div a', doc)[0].href;
     var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   getListImages : function(doc, curUrl) {
     var res = [];
   	eval($('body', doc).html().match(/var pages = .*n/)[0]);
@@ -81,23 +68,18 @@ var MangaYobai = {
   	});
     return res;
   },
-  
   removeBanners : function(doc, curUrl) {
     $(".ads", doc).remove();
   },
-  
   whereDoIWriteScans : function(doc, curUrl) {
     return $('#page', doc);
   },
-  
   whereDoIWriteNavigation : function(doc, curUrl) {
     return $(".navAMR", doc);
   },
-  
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return (curUrl.search('mangayobai.net/foolslide/reader/read/') > -1);
   },
-  
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     if (typeof doc.createElement == 'function') {
     	script = doc.createElement('script');
@@ -115,40 +97,33 @@ var MangaYobai = {
   	  $("#page", doc).css("width", "auto");
     });
   },
-  
   nextChapterUrl : function(select, doc, curUrl) {
     if ($(select).children("option:selected").prev().size() != 0) {
       return $(select).children("option:selected").prev().val();
     }
     return null;
   },
-  
   previousChapterUrl : function(select, doc, curUrl) {
     if ($(select).children("option:selected").next().size() != 0) {
       return $(select).children("option:selected").next().val();
     }
     return null;
   },
-  
   getImageFromPageAndWrite : function(urlImg, image, doc, curUrl) {
     $(image).attr("src", urlImg);
   },
-  
   isImageInOneCol : function(img, doc, curUrl) {
     return false;
   },
-  
   getMangaSelectFromPage : function(doc, curUrl) {
     return null;
   },
-  
   doAfterMangaLoaded : function(doc, curUrl) {
     $("body > div:empty", doc).remove();
     $("#page", doc).css("width", "auto");
     $("#page", doc).css("max-width", "none");
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MangaYobai", MangaYobai);

--- a/Mangable.js
+++ b/Mangable.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var Mangable = {
   //Name of the mirror
   mirrorName : "Mangable",
@@ -21,12 +19,10 @@ var Mangable = {
   mirrorIcon : "img/mangable.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("mangable.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var Mangable = {
      $.ajax(
         {
           url: "http://mangable.com/search/?series_name=" + search + "&submit=Search",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#comprehensive_list li .col1 > a:first-child", div).each(function(index) {
@@ -52,8 +46,7 @@ var Mangable = {
             callback("Mangable", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -62,32 +55,27 @@ var Mangable = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $("#newlist li a:first-child", div).each(function(index) {
               var tit = $(".audi b", $(this)).text();
               tit = tit.replace(mangaName, "").trim();
-              
               res[res.length] = [tit, $(this).attr("href")];
             });
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -95,24 +83,19 @@ var Mangable = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("#breadcrumbs li:nth-child(2) a", doc).text();
     currentMangaURL = "http://mangable.com" + $("#breadcrumbs li:nth-child(2) a", doc).attr("href");
-    
     currentChapter = $("#select_chapter option:selected", doc).text();
     currentChapterURL =  currentMangaURL + "chapter-" + $("#select_chapter option:selected", doc).val() + "/";
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL); */
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -120,7 +103,6 @@ var Mangable = {
     //This function runs in the DOM of the current consulted page.
     var currentMangaURL = "http://mangable.com" + $("#breadcrumbs li:nth-child(2) a", doc).attr("href"),
         currentChapterURL =  currentMangaURL + "chapter-" + $("#select_chapter option:selected", doc).val() + "/";
-    
     var res = [];
     $("#select_page select option", doc).each(
       function(index){
@@ -129,7 +111,6 @@ var Mangable = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -138,26 +119,22 @@ var Mangable = {
     $("#set1", doc).remove();
     $("#image_box td div").remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#image_box #image", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -173,7 +150,6 @@ var Mangable = {
     $(".scansAMR", doc).css("padding-top", "10px");
     $(".scansAMR", doc).css("padding-bottom", "10px");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -183,7 +159,6 @@ var Mangable = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -193,7 +168,6 @@ var Mangable = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -202,46 +176,38 @@ var Mangable = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("#image_box #image", div).attr("src");
-          
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     var currentMangaURL = "http://mangable.com" + $("#breadcrumbs li:nth-child(2) a", doc).attr("href");
-
     $("#select_chapter option", doc).each(function(index) {
       $(this).val(currentMangaURL + "chapter-" + $(this).val() + "/");
     });
-    
     return $("#select_chapter", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Mangable", Mangable);

--- a/Mangacurse.js
+++ b/Mangacurse.js
@@ -4,14 +4,12 @@
 //   Copyright (c) Enter here your copyright mention...                      //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 //This class is an example of manga site following implementation for All Manga Reader.
 //To test this class, just modify the json variable in mgEntry.js.
-//If your implementation works and has been fully tested, send it to me with an 
+//If your implementation works and has been fully tested, send it to me with an
 //icon (png with transparency file, 16x16) for your mirror
 //at pl dot duhoux (at) gmail dot com. I will add it in the extension.
 //If you have problems implementing your mirror, send me a mail... i will be glad to help you...
-
 //CHANGE here the classname
 var Mangacurse = {
   //CHANGE : Name of the mirror
@@ -21,12 +19,10 @@ var Mangacurse = {
   //CHANGE : Extension internal link to the icon of the mirror. (if not filled, will be blank...)
   mirrorIcon : "img/mangacurse.png",
   languages: "en",
-
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("mangacurse.info") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -36,26 +32,22 @@ var Mangacurse = {
         {
           //CHANGE URL HERE
           url: "http://mangacurse.info/reader/reader/list/",
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $('.list.series > .group > .title > a', div).each(function(index) {
 			  res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-
             callback("Mangacurse", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -65,38 +57,32 @@ var Mangacurse = {
         {
           //CHANGE URL HERE
           url: urlManga,
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $('.list > .element > .title > a', div).each(function(index) {
               res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-            
             callback(res, obj);
           }
     });
   },
-
   /********************************************************************************************************
     IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
     However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
     of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
     the object doc (example, replace $("select") by $("select", doc) in jQuery).
   ********************************************************************************************************/
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -104,13 +90,11 @@ var Mangacurse = {
     var currentChapter = $('.tbtitle div a', doc)[1].text;
     var currentMangaURL = $('.tbtitle div a', doc)[0].href;
     var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -123,19 +107,16 @@ var Mangacurse = {
   	});
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".ads", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     return $('#page', doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -144,12 +125,10 @@ var Mangacurse = {
     //you can change the DOM of the page before this method is called in doSomethingBeforeWritingScans
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return (curUrl.search('mangacurse.info/reader/reader/read/') > -1);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
 	script = doc.createElement('script');
@@ -166,7 +145,6 @@ var Mangacurse = {
   	  $("#page", doc).css("width", "100%");
     });
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -176,7 +154,6 @@ var Mangacurse = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -186,7 +163,6 @@ var Mangacurse = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -195,8 +171,7 @@ var Mangacurse = {
     //This function runs in the DOM of the current consulted page.
     $(image).attr("src", urlImg);
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
@@ -204,19 +179,16 @@ var Mangacurse = {
     //DO NOT CHANGE IF NOT NEEDED, NOT USED BY ANY EXISTING MIRROR AND CHAPTER'S DISPLAY IS WORKING FINE FOR THEM
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //RETURN A SELECT IF NEEDED, ELSE, THE EXTENSIOn WILL FIND CHAPTER BY IT'S OWN MEANS
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     //THE FOLLOWING LINE IS NECESSARY IN MOST OF CASES
     $("body > div:empty", doc).remove();
     $("#page", doc).css("width", "auto");
@@ -224,7 +196,6 @@ var Mangacurse = {
     //DO ANYTHING ELSE YOU NEED
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Mangacurse", Mangacurse);

--- a/Mangaholic.js
+++ b/Mangaholic.js
@@ -130,7 +130,6 @@ var Mangaholic = {
 		$("#page", doc).css("max-width", "none");
 	},
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Mangaholic", Mangaholic);

--- a/Mangajoy.js
+++ b/Mangajoy.js
@@ -177,7 +177,6 @@ var Mangajoy = {
 		return null;
 	}
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Mangajoy", Mangajoy);

--- a/MangasProject.js
+++ b/MangasProject.js
@@ -4,26 +4,22 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 function parseToLink(str)
 {
   	str = str.replace(/[ .]/g,"-").replace(/\//g,"");
     return str;
 }
-
 var MangasProject =
 {
 	mirrorName: "Mangas Project",
 	canListFullMangas: true,
 	mirrorIcon: "img/mangasproject.png",
 	languages: "pt",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("mangas.xpg.com.br/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -37,7 +33,7 @@ var MangasProject =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
 				var obj = JSON.parse(objResponse).All;
@@ -50,8 +46,7 @@ var MangasProject =
 				callback("Mangas Project", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -68,11 +63,10 @@ var MangasProject =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
 				var objR = JSON.parse(objResponse)["1"];
-
 				var res = [];
 				if (objR != undefined)
 				{
@@ -82,18 +76,17 @@ var MangasProject =
 						for (var i = 0; i < objR[j].releases.length; i++)
 						{
 							res[res.length] = [name + " (" + objR[j].releases[i].groupName + ")", "http://mangas.xpg.com.br/reader/?rel=" + objR[j].releases[i].releaseId];
-						} 
+						}
 					}
 				}
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -102,16 +95,13 @@ var MangasProject =
 		var currentChapter;
 		var currentMangaURL;
 		var currentChapterURL;
-
 		currentChapterURL = $("meta[property='og:url']", doc).attr("content").replace("www.mangasproject", "mangas");
-
 		var pos = currentChapterURL.indexOf("?rel=");
 		var id = currentChapterURL.substring(pos + 5, currentChapterURL.length);
-
 		$.ajax(
 		{
 			url: "http://mangas.xpg.com.br/reader/listPages.php",
-			type: 'POST', 
+			type: 'POST',
 			data:
 			{
 				"rel": id,
@@ -120,22 +110,19 @@ var MangasProject =
 			success: function(objResponse)
 			{
 				var obj = JSON.parse(objResponse);
-
 				name = obj.series;
 				currentMangaURL = "http://mangas.xpg.com.br/Manga/"+obj.seriesId+"-"+parseToLink(obj.series);
 				currentChapter = obj.number + " " + obj.name + " (" + obj.group + ")";
-
 				callback(
 				{
-					"name": name, 
-					"currentChapter": currentChapter, 
-					"currentMangaURL": currentMangaURL, 
+					"name": name,
+					"currentChapter": currentChapter,
+					"currentMangaURL": currentMangaURL,
 					"currentChapterURL": currentChapterURL
 				});
 			}
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -145,12 +132,11 @@ var MangasProject =
 		var url = $("meta[property='og:url']", doc).attr("content");
 		var pos = url.indexOf("?rel=");
 		var id = url.substring(pos + 5, url.length);
-
 		var res = [];
 		$.ajax(
 		{
 			url: "http://mangas.xpg.com.br/reader/listPages.php",
-			type: 'POST', 
+			type: 'POST',
 			data:
 			{
 				"rel": id
@@ -181,14 +167,12 @@ var MangasProject =
 		});
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		$("#banner", doc).remove();
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -196,7 +180,6 @@ var MangasProject =
 	{
 		return $(".pageAMR", doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -204,13 +187,11 @@ var MangasProject =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage : function(doc, curUrl)
 	{
 		return ($("div.page", doc).size() > 0);
 	},
-
 	//This method is called before displaying full chapters in the page
 	//This function runs in the DOM of the current consulted page.
 	doSomethingBeforeWritingScans: function(doc, curUrl)
@@ -221,7 +202,6 @@ var MangasProject =
 		$("<div class='navAMR'></div>").appendTo($("#viewer", doc));
 		$("#viewer", doc).css("padding-top", "10px");
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -233,7 +213,6 @@ var MangasProject =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -245,7 +224,6 @@ var MangasProject =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -255,8 +233,7 @@ var MangasProject =
 	{
 		$(image).attr("src", urlImg);
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -264,15 +241,13 @@ var MangasProject =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -280,7 +255,6 @@ var MangasProject =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Mangas Project", MangasProject);

--- a/MenudoFansub.js
+++ b/MenudoFansub.js
@@ -130,7 +130,6 @@ var MenudoFansub = {
 		$("#page", doc).css("max-width", "none");
 	},
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("MenudoFansub", MenudoFansub);

--- a/MudaScantrad.js
+++ b/MudaScantrad.js
@@ -130,7 +130,6 @@ var MudaScantrad = {
     $("#page", doc).css("max-width", "none");
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Muda Scantrad", MudaScantrad);

--- a/Otakuyo.js
+++ b/Otakuyo.js
@@ -4,13 +4,11 @@ var Otakuyo =
 	canListFullMangas: false,
 	mirrorIcon: "img/otakuyo.png",
 	languages: "pt",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("leitor.otakuyo.com") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -29,23 +27,20 @@ var Otakuyo =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('.list > .group > .title > a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback("Otakuyo!!!", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -59,28 +54,24 @@ var Otakuyo =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
-
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div"); 
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('.list > .element > .title > a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -89,16 +80,14 @@ var Otakuyo =
 		var currentChapter = $('.tbtitle div a', doc)[1].text;
 		var currentMangaURL = $('.tbtitle div a', doc)[0].href;
 		var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-
 		callback(
 		{
 			"name": name,
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -112,21 +101,18 @@ var Otakuyo =
 		});
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		// No ads here
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('#page', doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -134,13 +120,11 @@ var Otakuyo =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return (curUrl.search('leitor.otakuyo.com/reader/read/') > -1);
 	},
-
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -162,7 +146,6 @@ var Otakuyo =
 			$("#page", doc).css("width", "100%");
 		});
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -174,7 +157,6 @@ var Otakuyo =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -186,7 +168,6 @@ var Otakuyo =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -196,8 +177,7 @@ var Otakuyo =
 	{
 		$(image).attr("src", urlImg);
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -205,15 +185,13 @@ var Otakuyo =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -221,7 +199,6 @@ var Otakuyo =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Otakuyo!!!", Otakuyo);

--- a/OurManga.js
+++ b/OurManga.js
@@ -148,7 +148,6 @@ var OurManga = {
         $("body > div:empty", e).remove()
     }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Our Manga", OurManga);

--- a/PunchMangas.js
+++ b/PunchMangas.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var PunchMangas = {
   //Name of the mirror
   mirrorName : "PunchMangas",
@@ -21,12 +19,10 @@ var PunchMangas = {
   mirrorIcon : "img/punchmangas.png",
   //Languages of scans for the mirror
   languages : "pt",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("punchmangas.com.br/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,26 +31,23 @@ var PunchMangas = {
      $.ajax(
         {
           url: "http://www.punchmangas.com.br/lmangas/Todos/titulo/c",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             //console.log($("#listagemMangas li", div).size());
             $("#listagemMangas > ul > li", div).each(function(index) {
               //console.log($($("a", $(this))[0]).contents().size());
               res[res.length] = [$($("a", $(this))[0]).contents().filter(function(){ return this.nodeType == 3; }).text(), $("#lLancs a", $(this)).attr("href")];
-            });   
+            });
             callback("PunchMangas", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -63,31 +56,25 @@ var PunchMangas = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $("#listagemCaps > ul > li", div).each(function(index) {
                 res[res.length] = [$($("a", $(this))[0]).contents().filter(function(){ return this.nodeType == 3; }).text(), $("#menuOpcoes a", $(this)).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -95,27 +82,20 @@ var PunchMangas = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-    
     var a = $("#paginaCaminho a[href^='http://www.punchmangas.com.br/listagem/']", doc);
     name = a.text();
     currentMangaURL = a.attr("href");
-    
     currentChapter = $("#listaDeCaps option:selected", doc).text();
     currentChapterURL = $("#listaDeCaps option:selected", doc).val();
-
-    
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -123,12 +103,10 @@ var PunchMangas = {
     //This function runs in the DOM of the current consulted page.
     var res = [];
     var base;
-    
     $("script", doc).each(function(index) {
       if ($(this).text().indexOf("jQuery.preLoadImages(\"") != -1) {
         var posdeb = $(this).text().indexOf("jQuery.preLoadImages(\"");
-        var posfin = $(this).text().indexOf("\"", posdeb + 23); 
-        
+        var posfin = $(this).text().indexOf("\"", posdeb + 23);
         base = $(this).text().substring(posdeb + 22, posfin);
       }
     });
@@ -137,47 +115,38 @@ var PunchMangas = {
       if (parseInt(num, 10) < 10) num = "0" + num;
       res[res.length] = base + num + ".jpg";
     });
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#imagemPagina", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#controles", doc).add($("#leitorRodape", doc));
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#imagemAtual", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("#controles", doc).empty();
     $("#leitorTopo", doc).css("height", "auto");
-    
     $("#leitorRodape", doc).empty();
     $("#imagemPagina", doc).empty();
     $("#imagemPagina", doc).css("background-color", "black");
     $("#imagemPagina", doc).css("padding-top", "10px");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -187,7 +156,6 @@ var PunchMangas = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -197,7 +165,6 @@ var PunchMangas = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -206,29 +173,25 @@ var PunchMangas = {
     //This function runs in the DOM of the current consulted page.
     $( image ).attr( "src", urlImg );
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#listaDeCaps", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("PunchMangas", PunchMangas);

--- a/Pururin.js
+++ b/Pururin.js
@@ -4,13 +4,11 @@ var Pururin =
 	canListFullMangas: false,
 	mirrorIcon: "img/pururin.png",
 	languages: "pt",
-
 	//Return true if the url corresponds to the mirror
 	isMe: function(url)
 	{
 		return (url.indexOf("pururin.com.br/leitor/") != -1);
 	},
-
 	//Return the list of all or part of all mangas from the mirror
 	//The search parameter is filled if canListFullMangas is false
 	//This list must be an Array of [["manga name", "url"], ...]
@@ -29,23 +27,20 @@ var Pururin =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div");  
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('.list > .group > .title > a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback("Pururin", res);
 			}
 		});
-	}, 
-
+	},
 	//Find the list of all chapters of the manga represented by the urlManga parameter
 	//This list must be an Array of [["chapter name", "url"], ...]
 	//This list must be sorted descending. The first element must be the most recent.
@@ -59,28 +54,24 @@ var Pururin =
 			{
 				xhr.setRequestHeader("Cache-Control", "no-cache");
 				xhr.setRequestHeader("Pragma", "no-cache");
-			}, 
-
+			},
 			success: function(objResponse)
 			{
-				var div = document.createElement("div"); 
+				var div = document.createElement("div");
 				div.innerHTML = objResponse;
-
 				var res = [];
 				$('td.p1 a', div).each(function(index)
 				{
 					res.push([$(this).attr('title'), $(this).attr('href')]);
 				});
-
 				callback(res, obj);
 			}
 		});
 	},
-
-	//This method must return (throught callback method) an object like : 
-	//{"name" : Name of current manga, 
-	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-	//  "currentMangaURL": Url to access current manga, 
+	//This method must return (throught callback method) an object like :
+	//{"name" : Name of current manga,
+	//  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+	//  "currentMangaURL": Url to access current manga,
 	//  "currentChapterURL": Url to access current chapter}
 	//This function runs in the DOM of the current consulted page.
 	getInformationsFromCurrentPage: function(doc, curUrl, callback)
@@ -89,16 +80,14 @@ var Pururin =
 		var currentChapter = $('.tbtitle div a', doc)[1].text;
 		var currentMangaURL = $('.tbtitle div a', doc)[0].href;
 		var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-
 		callback(
 		{
 			"name": name,
-			"currentChapter": currentChapter, 
-			"currentMangaURL": currentMangaURL, 
+			"currentChapter": currentChapter,
+			"currentMangaURL": currentMangaURL,
 			"currentChapterURL": currentChapterURL
 		});
-	}, 
-
+	},
 	//Returns the list of the urls of the images of the full chapter
 	//This function can return urls which are not the source of the
 	//images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -112,21 +101,18 @@ var Pururin =
 		});
 		return res;
 	},
-
 	//Remove the banners from the current page
 	//This function runs in the DOM of the current consulted page.
 	removeBanners: function(doc, curUrl)
 	{
 		// No ads here
 	},
-
 	//This method returns the place to write the full chapter in the document
 	//The returned element will be totally emptied.
 	whereDoIWriteScans: function(doc, curUrl)
 	{
 		return $('#page', doc);
 	},
-
 	//This method returns places to write the navigation bar in the document
 	//The returned elements won't be emptied.
 	//This function runs in the DOM of the current consulted page.
@@ -134,13 +120,11 @@ var Pururin =
 	{
 		return $(".navAMR", doc);
 	},
-
 	//Return true if the current page is a page containing scan.
 	isCurrentPageAChapterPage: function(doc, curUrl)
 	{
 		return (curUrl.search('pururin.com.br/leitor/reader/read/') > -1);
 	},
-
 	//This method is called before displaying full chapters in the page
 	doSomethingBeforeWritingScans: function(doc, curUrl)
 	{
@@ -162,7 +146,6 @@ var Pururin =
 			$("#page", doc).css("width", "100%");
 		});
 	},
-
 	//This method is called to fill the next button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -174,7 +157,6 @@ var Pururin =
 		}
 		return null;
 	},
-
 	//This method is called to fill the previous button's url in the manga site navigation bar
 	//The select containing the mangas list next to the button is passed in argument
 	//This function runs in the DOM of the current consulted page.
@@ -186,7 +168,6 @@ var Pururin =
 		}
 		return null;
 	},
-
 	//Write the image from the the url returned by the getListImages() function.
 	//The function getListImages can return an url which is not the source of the
 	//image. The src of the image is set by this function.
@@ -196,8 +177,7 @@ var Pururin =
 	{
 		$(image).attr("src", urlImg);
 	},
-
-	//If it is possible to know if an image is a credit page or something which 
+	//If it is possible to know if an image is a credit page or something which
 	//must not be displayed as a book, just return true and the image will stand alone
 	//img is the DOM object of the image
 	//This function runs in the DOM of the current consulted page.
@@ -205,15 +185,13 @@ var Pururin =
 	{
 		return false;
 	},
-
-	//This function can return a preexisting select from the page to fill the 
+	//This function can return a preexisting select from the page to fill the
 	//chapter select of the navigation bar. It avoids to load the chapters
 	//This function runs in the DOM of the current consulted page.
 	getMangaSelectFromPage: function(doc, curUrl)
 	{
 		return null;
 	},
-
 	//This function is called when the manga is full loaded. Just do what you want here...
 	//This function runs in the DOM of the current consulted page.
 	doAfterMangaLoaded: function(doc, curUrl)
@@ -221,7 +199,6 @@ var Pururin =
 		$("body > div:empty", doc).remove();
 	}
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Pururin", Pururin);

--- a/ReadManga.js
+++ b/ReadManga.js
@@ -137,7 +137,6 @@ var ReadManga = {
 		$("body > div:empty", doc).remove();
 	},
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("ReadManga", ReadManga);

--- a/Redhawkscans.js
+++ b/Redhawkscans.js
@@ -131,7 +131,6 @@ var Redhawkscans = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Redhawkscans", Redhawkscans);

--- a/S2scans.js
+++ b/S2scans.js
@@ -139,7 +139,6 @@ var S2scans = {
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("S2scans", S2scans);

--- a/SimpleScans.js
+++ b/SimpleScans.js
@@ -128,7 +128,6 @@ var SimpleScans = {
         $("body > div:empty", e).remove()
     }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Simple Scans", SimpleScans);

--- a/StopTazmo.js
+++ b/StopTazmo.js
@@ -132,7 +132,6 @@ var StopTazmo = {
         $("body > div:empty", e).remove()
     }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("StopTazmo", StopTazmo);

--- a/SubManga.js
+++ b/SubManga.js
@@ -7,12 +7,10 @@ var SubManga = {
   mirrorIcon : "img/submanga.png",
   //Languages of scans for the mirror
   languages : "es",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("submanga.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -21,14 +19,12 @@ var SubManga = {
      $.ajax(
         {
           url: "http://submanga.com/series/n",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("#w .b468 td:first-child a", div).each(function(index) {
@@ -40,8 +36,7 @@ var SubManga = {
             callback("SubManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -50,32 +45,28 @@ var SubManga = {
      $.ajax(
         {
           url: urlManga + "/completa",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $("#w .b468 .caps td:first-child a", div).each(function(index) {
               var ref = $(this).attr("href");
               var pos = ref.lastIndexOf("/");
               ref = "http://submanga.com/c/" + ref.substr(pos + 1, ref.length);
 			  res[res.length] = [$("strong", $(this)).text(), ref];
-            }); 
+            });
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -83,25 +74,21 @@ var SubManga = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     name = $("td.l a:nth-child(3)", doc).text();
     var ref = $("td.l a:nth-child(3)", doc).attr("href").replace("/scanlation/", "/").substr(2);
     var pos = ref.lastIndexOf("/");
     ref = "http://submanga.com/" + ref.substr(0, pos);
     currentMangaURL = ref;
-    
     currentChapter = $("td.l a:nth-child(4)", doc).text();
     ref = $("td.l a:nth-child(4)", doc).attr("href").replace("/scanlation/", "/");
     pos = ref.lastIndexOf("/");
     ref = "http://submanga.com/c/" + ref.substr(pos + 1, ref.length);
     currentChapterURL = ref;
-            
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -109,7 +96,6 @@ var SubManga = {
     //This function runs in the DOM of the current consulted page.
     var res = [];
 	var path = curUrl;
-	
     $("table#t select option", doc).each(
       function(index){
         res[index] = path + "/" + $(this).val();
@@ -117,31 +103,26 @@ var SubManga = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $("#scan", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#t", doc).size() > 0 && $("div a img", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
 	// this code remove the fixed style from table create for this extension
@@ -150,30 +131,25 @@ var SubManga = {
 	$("body",doc).attr("bgcolor","#000");
 	$("body",doc).attr("margin","0");
 	$("body",doc).attr("padding","0");
-	
 	$("#t",doc).attr("bgcolor","#1c6a6d");
 	$("#t",doc).attr("width","100%");
 	$("#t",doc).css("sppanding","4px");
 	$("#t",doc).css("font","400 11px 'verdana'");
 	$("#t",doc).css("margin","4px");
 	$("#t",doc).css("padding","6px");
-	
 	$("#t a",doc).css("text-decoration","none");
 	$("#t a",doc).css("color","white");
 	$("#t th",doc).last().remove();
 	$("#t th",doc).last().remove();
 	$("#t th",doc).last().remove();
 	$("#t select",doc).last().remove();
-
     //This function runs in the DOM of the current consulted page.
     $("body div", doc).empty();
     $("body div", doc).append("<div id='scan'></div>");
     $("#scan", doc).before($("<div class='navAMR'></div>"));
     $("#scan", doc).after($("<div class='navAMR'></div>"));
 	$(".navAMR", doc).css("text-align", "center");
-
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -183,7 +159,6 @@ var SubManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -193,49 +168,42 @@ var SubManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
   //If getListImages function returns the src of the image, just do $( image ).attr( "src", urlImg );
-  getImageFromPageAndWrite : function(urlImg, image, doc, curUrl) {	
+  getImageFromPageAndWrite : function(urlImg, image, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
-    
+          div.innerHTML = objResponse;
           var src = $("div a img", div).attr("src");
-          
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //$("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("SubManga", SubManga);

--- a/TenManga.js
+++ b/TenManga.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var TenManga = {
   //Name of the mirror
   mirrorName : "TenManga",
@@ -21,12 +19,10 @@ var TenManga = {
   mirrorIcon : "img/tenmanga.png",
   //Languages of scans for the mirror
   languages : "en,zh",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("tenmanga.com/") != -1 || url.indexOf("dm72.com/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var TenManga = {
      $.ajax(
         {
           url: "http://www.fullcomic.com/list/?wd=" + search,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("dt > a:first-child", div).each(function(index) {
@@ -52,8 +46,7 @@ var TenManga = {
             callback("TenManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -62,16 +55,13 @@ var TenManga = {
      $.ajax(
         {
           url: urlManga + ((urlManga.indexOf("tenmanga.com/") != -1) ? "?waring=1" : ""),
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             if (urlManga.indexOf("tenmanga.com/") != -1) {
               $(".chapter_list tr td:first-child a", div).each(function(index) {
@@ -92,11 +82,10 @@ var TenManga = {
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -107,33 +96,28 @@ var TenManga = {
     if (curUrl.indexOf("tenmanga.com/") != -1) {
       name = $(".chapter_bar div.postion span.normal a:nth-child(2)", doc).text().trim();
       currentMangaURL = $(".chapter_bar div.postion span.normal a:nth-child(2)", doc).attr("href");
-      
       currentChapter = $("select#chapter:first option:selected", doc).text();
       currentChapterURL = $("select#chapter:first option:selected", doc).val();
     } else if (curUrl.indexOf("www.dm72.com/") != -1) {
       name = $(".juan .top_guide > div:first a:nth-child(3)", doc).text().trim();
       currentMangaURL = "http://www.dm72.com" + $(".juan .top_guide > div:first a:nth-child(3)", doc).attr("href");
-      
       currentChapter = $("select#juan_list:first option:selected", doc).text();
       currentChapterURL = "http://www.dm72.com" + $("select#juan_list:first option:selected", doc).val();
     } else {
       name = $(".main_bar div.postion span.normal a:nth-child(2)", doc).text().trim();
       currentMangaURL = $(".main_bar div.postion span.normal a:nth-child(2)", doc).attr("href");
-      
       currentChapter = $("select#chapter:first option:selected", doc).text();
       currentChapterURL = $("select#chapter:first option:selected", doc).val();
     }
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -156,10 +140,8 @@ var TenManga = {
         res[res.length] = $(this).val();
       });
     }
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -168,21 +150,18 @@ var TenManga = {
       $(".outer", doc).parent().next().remove();
     }
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     if (curUrl.indexOf("tenmanga.com/") != -1) {
@@ -193,7 +172,6 @@ var TenManga = {
       return ($("img", $(".outer", doc).next().next()).size() > 0);
     }
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -220,7 +198,6 @@ var TenManga = {
     $(".scansAMR", doc).css("background-color", "black");
     $(".scansAMR", doc).css("padding-top", "10px");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -230,7 +207,6 @@ var TenManga = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -240,7 +216,6 @@ var TenManga = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -249,10 +224,10 @@ var TenManga = {
     //This function runs in the DOM of the current consulted page.
    $.ajax(
       {
-        url: urlImg,         
+        url: urlImg,
         success: function( objResponse ){
           var div = document.createElement( "div" );
-          div.innerHTML = objResponse; 
+          div.innerHTML = objResponse;
           var src;
           if (curUrl.indexOf("tenmanga.com/") != -1) {
             src = $("img#comicpic", div).attr("src");
@@ -261,21 +236,18 @@ var TenManga = {
           } else {
             src = $($("img", $(".outer", div).next().next())[0]).attr("src");
           }
-
           $( image ).attr( "src", src);
         }
     });
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -290,14 +262,12 @@ var TenManga = {
       return $("select#chapter:first", doc);
     }
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("TenManga", TenManga);

--- a/ThHour.js
+++ b/ThHour.js
@@ -95,7 +95,6 @@ var ThHour = {
             script.innerText += "$(document).unbind('keypress');";
             doc.body.appendChild(script);
         }
-
         $("#page", doc).before("<div class='navAMR'></div>");
         $("#page", doc).after("<div class='navAMR'></div>");
         $("#page", doc).css("width", "auto");
@@ -131,7 +130,6 @@ var ThHour = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("13Th Hour Scanlations", ThHour);

--- a/TheSpectrum.js
+++ b/TheSpectrum.js
@@ -203,7 +203,6 @@ var TheSpectrum = {
         $("body > div:empty", doc).remove();
     },
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("The Spectrum", TheSpectrum);

--- a/Titania.js
+++ b/Titania.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var Titania = {
   //Name of the mirror
   mirrorName : "Titania Scanlations",
@@ -21,12 +19,10 @@ var Titania = {
   mirrorIcon : "img/titania.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("www.titaniascans.com/reader/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var Titania = {
      $.ajax(
         {
           url: "http://www.titaniascans.com/reader/",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $(".selector .options a", div).each(function(index) {
@@ -51,8 +45,7 @@ var Titania = {
             callback("Titania Scanlations", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -61,27 +54,21 @@ var Titania = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $(".theList a:has(.chapter)", div).each(function(index) {
                 res[res.length] = [$("b", $(this)).text().trim(), $(this).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
   retrieveInfo: function(sel) {
     var _obj = {};
     var curval = $(sel.contents()[0]).text();
@@ -92,11 +79,10 @@ var Titania = {
     });
     return _obj;
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -104,25 +90,21 @@ var Titania = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-    
     var manga = Titania.retrieveInfo($($(".selector", doc)[0]));
     var chapter = Titania.retrieveInfo($($(".selector", doc)[1]));
     name = manga.name;
     currentChapter = chapter.name;
     currentChapterURL = chapter.url;
     currentMangaURL = manga.url;
-    
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -141,39 +123,32 @@ var Titania = {
         }
       }
     });
-    
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".ads", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scanAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#theManga #thePic", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     $("#theManga", doc).empty();
     var cloned = $("#theManga", doc).clone();
     $("#theManga", doc).after(cloned);
@@ -191,7 +166,6 @@ var Titania = {
 	script.innerText += "$(document).unbind('hashchange');";
 	doc.body.appendChild(script);
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -201,7 +175,6 @@ var Titania = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -211,7 +184,6 @@ var Titania = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -220,16 +192,14 @@ var Titania = {
     //This function runs in the DOM of the current consulted page.
    $( image ).attr( "src", urlImg );
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -244,8 +214,7 @@ var Titania = {
       $("<option value=\"" + $(this).attr("href") + "\"" + (iscur ? "selected=\"selected\"" : "") + ">" + $(".option", $(this)).text().trim() + "</option>").appendTo(ret);
     });
     return ret;
-  },  
-  
+  },
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -253,7 +222,6 @@ var Titania = {
 	$('#infoSpread').remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Titania Scanlations", Titania);

--- a/Trinitybakuma.js
+++ b/Trinitybakuma.js
@@ -178,7 +178,6 @@ var Trinitybakuma = {
         $('#infoSpread').hide();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Trinity BAKumA", Trinitybakuma);

--- a/TwinDragons.js
+++ b/TwinDragons.js
@@ -4,7 +4,6 @@
 //   Copyright (c) Enter here your copyright mention...                      //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 //CHANGE here the classname
 var TwinDragons = {
   //CHANGE : Name of the mirror
@@ -14,12 +13,10 @@ var TwinDragons = {
   //CHANGE : Extension internal link to the icon of the mirror. (if not filled, will be blank...)
   mirrorIcon : "img/TwinDragons.png",
   languages: "es",
-
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("twindragons-scans.com/reader") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -29,26 +26,22 @@ var TwinDragons = {
         {
           //CHANGE URL HERE
           url: "http://twindragons-scans.com/reader/reader/list/",
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $('.list.series > .group > .title > a', div).each(function(index) {
 			  res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-
             callback("Twin Dragons no Fansub", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -58,38 +51,32 @@ var TwinDragons = {
         {
           //CHANGE URL HERE
           url: urlManga,
-          
           //KEEP THE HEADERS, THEY PREVENT CHROME TO LOAD URL FROM CACHE
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-          
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
             $('.list > .element > .title > a', div).each(function(index) {
               res[res.length] = [$(this).attr('title'), $(this).attr('href')];
             });
-            
             callback(res, obj);
           }
     });
   },
-
   /********************************************************************************************************
     IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
     However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
     of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
     the object doc (example, replace $("select") by $("select", doc) in jQuery).
   ********************************************************************************************************/
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -97,13 +84,11 @@ var TwinDragons = {
     var currentChapter = $('.tbtitle div a', doc)[1].text;
     var currentMangaURL = $('.tbtitle div a', doc)[0].href;
     var currentChapterURL = $('.tbtitle div a', doc)[1].href;
-    
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -116,19 +101,16 @@ var TwinDragons = {
   	});
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $(".ads", doc).remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     return $('#page', doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
@@ -137,12 +119,10 @@ var TwinDragons = {
     //you can change the DOM of the page before this method is called in doSomethingBeforeWritingScans
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return (curUrl.search('twindragons-scans.com/reader/reader/read/') > -1);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     if (typeof doc.createElement == 'function') {
@@ -161,7 +141,6 @@ var TwinDragons = {
   	  $("#page", doc).css("width", "auto");
     });
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -171,7 +150,6 @@ var TwinDragons = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -181,7 +159,6 @@ var TwinDragons = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -190,8 +167,7 @@ var TwinDragons = {
     //This function runs in the DOM of the current consulted page.
     $(image).attr("src", urlImg);
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
@@ -199,19 +175,16 @@ var TwinDragons = {
     //DO NOT CHANGE IF NOT NEEDED, NOT USED BY ANY EXISTING MIRROR AND CHAPTER'S DISPLAY IS WORKING FINE FOR THEM
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     //RETURN A SELECT IF NEEDED, ELSE, THE EXTENSIOn WILL FIND CHAPTER BY IT'S OWN MEANS
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     //THE FOLLOWING LINE IS NECESSARY IN MOST OF CASES
     $("body > div:empty", doc).remove();
     $("#page", doc).css("width", "auto");
@@ -219,7 +192,6 @@ var TwinDragons = {
     //DO ANYTHING ELSE YOU NEED
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Twin Dragons no Fansub", TwinDragons);

--- a/UnixManga.js
+++ b/UnixManga.js
@@ -4,7 +4,6 @@
 //   Copyright (c) 2011 Matteo TeoMan Mangano (MM.teoman at gmail dot com)   //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
@@ -16,16 +15,13 @@ var getListChapsInnerCnt = 0;
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             if ($("div[id='mycontent']", div).size() > 0)
             {
                 // Regular chapters and sub-chapters
@@ -40,7 +36,7 @@ var getListChapsInnerCnt = 0;
                       getListChapsInnerCnt++;
                       //getListChapsInner($(this).attr("href"), mangaName, obj, callback, res, level + 1);
                       var subUrl = $(this).attr("href");
-                      window.setTimeout (function () { getListChapsInner(subUrl, mangaName, obj, callback, res, level + 1); }, 500 * getListChapsInnerCnt); 
+                      window.setTimeout (function () { getListChapsInner(subUrl, mangaName, obj, callback, res, level + 1); }, 500 * getListChapsInnerCnt);
                     }
                   }
                 });
@@ -56,7 +52,6 @@ var getListChapsInnerCnt = 0;
                   name = mangaName + " " + name;
                 res[res.length] = [name, urlManga.substr(0, urlManga.length - 5) + "_nas.html"];
             }
-        
             if (getListChapsInnerCnt <= 0) {
               callback(res, obj);
               getListChapsInnerCnt = 0;
@@ -66,8 +61,6 @@ var getListChapsInnerCnt = 0;
           }
     });
   }
-
-
 var UnixManga = {
   //Name of the mirror
   mirrorName : "UnixManga",
@@ -77,12 +70,10 @@ var UnixManga = {
   mirrorIcon : "img/UnixManga.png",
   //Languages of scans for the mirror
   languages : "en",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("http://unixmanga.com") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -93,14 +84,12 @@ var UnixManga = {
           type: 'POST',
           url: "http://unixmanga.com/onlinereading/manga-lists.html",
           data: {word: search},
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $("table.snif tr td a", div).each(function(index) {
@@ -109,8 +98,7 @@ var UnixManga = {
             callback("UnixManga", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -119,11 +107,10 @@ var UnixManga = {
     var res = [];
     getListChapsInner(urlManga, mangaName, obj, callback, res, 0);
   },
-
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -131,7 +118,6 @@ var UnixManga = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-
     var pos1 = curUrl.indexOf("/onlinereading/");
 //    var pos2 = curUrl.indexOf("/", pos1 + 15);
 //    if (pos2 == -1 && $("div[id='mycontent']", doc).size() != 0)
@@ -160,18 +146,15 @@ var UnixManga = {
     while(currentChapter.indexOf("_") != -1)
         currentChapter = currentChapter.replace("_", " ");
     currentChapterURL = curUrl;
-
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-   }, 
-  
+   },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -188,33 +171,28 @@ var UnixManga = {
     );
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     if ($("div[id='content'] a", doc).size() == 0)
       return false;
     return ($("div[id='content'] a", doc).first().attr("href").indexOf("?image") != -1);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -237,31 +215,25 @@ var UnixManga = {
     $("#wrap", doc).css("width", "auto");
     $("#menu", doc).css("width", "800px");
     $("#bottom", doc).remove();
-     
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-
     if ($(select).children("option:selected").prev().size() != 0) {
       return $(select).children("option:selected").prev().val();
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-
     if ($(select).children("option:selected").next().size() != 0) {
       return $(select).children("option:selected").next().val();
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -270,33 +242,27 @@ var UnixManga = {
     //This function runs in the DOM of the current consulted page.
     $( image ).attr( "src", urlImg );
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return null;
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
-    
     //THE FOLLOWING LINE IS NECESSARY IN MOST OF CASES
     $("body > div:empty", doc).remove();
-    
     //DO ANYTHING ELSE YOU NEED
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("UnixManga", UnixManga);

--- a/VNSharing.js
+++ b/VNSharing.js
@@ -4,14 +4,12 @@
 //   Copyright (c) 2011 Pierre-Louis DUHOUX (pl.duhoux at gmail d0t com)     //
 //                                                                           //
 /////////////////////////////////////////////////////////////////////////////*/
-
 /********************************************************************************************************
   IMPORTANT NOTE : methods which are running in the DOM of the page could directly use this DOM.
   However, if you want to test the mirror with the lab, you must use the two arguments (doc and curUrl)
   of these methods to avoid using window.location.href (replaced by curUrl) and manipulate the DOM within
   the object doc (example, replace $("select") by $("select", doc) in jQuery).
 ********************************************************************************************************/
-
 var VNSharing = {
   //Name of the mirror
   mirrorName : "VNSharing",
@@ -21,12 +19,10 @@ var VNSharing = {
   mirrorIcon : "img/vnsharing.png",
   //Languages of scans for the mirror
   languages : "vi",
-  
   //Return true if the url corresponds to the mirror
   isMe : function(url) {
     return (url.indexOf("truyen.vnsharing.net/") != -1);
   },
-  
   //Return the list of all or part of all mangas from the mirror
   //The search parameter is filled if canListFullMangas is false
   //This list must be an Array of [["manga name", "url"], ...]
@@ -35,14 +31,12 @@ var VNSharing = {
      $.ajax(
         {
           url: "http://truyen.vnsharing.net/DanhSach",
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" );  
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
             var res = [];
             $(".listing tr td:first-child a", div).each(function(index) {
@@ -52,8 +46,7 @@ var VNSharing = {
             callback("VNSharing", res);
           }
     });
-  }, 
-  
+  },
   //Find the list of all chapters of the manga represented by the urlManga parameter
   //This list must be an Array of [["chapter name", "url"], ...]
   //This list must be sorted descending. The first element must be the most recent.
@@ -62,31 +55,25 @@ var VNSharing = {
      $.ajax(
         {
           url: urlManga,
-          
           beforeSend: function(xhr) {
             xhr.setRequestHeader("Cache-Control", "no-cache");
             xhr.setRequestHeader("Pragma", "no-cache");
-          }, 
-           
+          },
           success: function( objResponse ){
-            var div = document.createElement( "div" ); 
+            var div = document.createElement( "div" );
             div.innerHTML = objResponse;
-            
             var res = [];
-
               $(".listing:first tr td:first-child a", div).each(function(index) {
                 res[res.length] = [$(this).text().trim(), "http://truyen.vnsharing.net" + $(this).attr("href")];
               });
-
             callback(res, obj);
           }
     });
   },
-  
-  //This method must return (throught callback method) an object like : 
-  //{"name" : Name of current manga, 
-  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps), 
-  //  "currentMangaURL": Url to access current manga, 
+  //This method must return (throught callback method) an object like :
+  //{"name" : Name of current manga,
+  //  "currentChapter": Name of thee current chapter (one of the chapters returned by getListChaps),
+  //  "currentMangaURL": Url to access current manga,
   //  "currentChapterURL": Url to access current chapter}
   getInformationsFromCurrentPage : function(doc, curUrl, callback) {
     //This function runs in the DOM of the current consulted page.
@@ -94,7 +81,6 @@ var VNSharing = {
     var currentChapter;
     var currentMangaURL;
     var currentChapterURL;
-    
     name = $("#navsubbar a:first", doc).text().trim();
     var pos = name.indexOf("\n");
     if (pos != -1) name = name.substr(pos).trim();
@@ -102,23 +88,18 @@ var VNSharing = {
     pos = team.indexOf("\n");
     if (pos != -1) team = team.substr(pos).trim();
     name += " (" + team + ")";
-    
     currentMangaURL = $("#navsubbar a:first", doc).attr("href");
-    
     currentChapter = $("#selectChapter option:selected", doc).text();
     currentChapterURL = currentMangaURL + "/" + $("#selectChapter option:selected", doc).val();
-
-    /*console.log(" name : " + name +  
-            " currentChapter : " + currentChapter + 
-            " currentMangaURL : " + currentMangaURL + 
+    /*console.log(" name : " + name +
+            " currentChapter : " + currentChapter +
+            " currentMangaURL : " + currentMangaURL +
             " currentChapterURL : " + currentChapterURL);*/
-              
-    callback({"name": name, 
-            "currentChapter": currentChapter, 
-            "currentMangaURL": currentMangaURL, 
+    callback({"name": name,
+            "currentChapter": currentChapter,
+            "currentMangaURL": currentMangaURL,
             "currentChapterURL": currentChapterURL});
-  }, 
-  
+  },
   //Returns the list of the urls of the images of the full chapter
   //This function can return urls which are not the source of the
   //images. The src of the image is set by the getImageFromPageAndWrite() function.
@@ -127,7 +108,6 @@ var VNSharing = {
     /*var res = [];
     var mg = "http://truyen.vnsharing.net" + $("#navsubbar a:first", doc).attr("href");
     var chap = mg + "/" + $("#selectChapter option:selected", doc).val();
-
     $("#selectPage option", doc).each(function(index) {
       res[res.length] = chap + "#" + $(this).val();
     });
@@ -146,32 +126,27 @@ var VNSharing = {
     });
     return res;
   },
-  
   //Remove the banners from the current page
   removeBanners : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("iframe", doc).parents("ins").remove();
   },
-  
   //This method returns the place to write the full chapter in the document
   //The returned element will be totally emptied.
   whereDoIWriteScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".scansAMR", doc);
   },
-  
   //This method returns places to write the navigation bar in the document
   //The returned elements won't be emptied.
   whereDoIWriteNavigation : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return $(".navAMR", doc);
   },
-  
   //Return true if the current page is a page containing scan.
   isCurrentPageAChapterPage : function(doc, curUrl) {
     return ($("#imgCurrent", doc).size() > 0);
   },
-  
   //This method is called before displaying full chapters in the page
   doSomethingBeforeWritingScans : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
@@ -182,7 +157,6 @@ var VNSharing = {
     $(".navAMR", doc).css("text-align", "center");
     $(".navAMR", doc).css("width", "100%");
   },
-  
   //This method is called to fill the next button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   nextChapterUrl : function(select, doc, curUrl) {
@@ -192,7 +166,6 @@ var VNSharing = {
     }
     return null;
   },
-  
   //This method is called to fill the previous button's url in the manga site navigation bar
   //The select containing the mangas list next to the button is passed in argument
   previousChapterUrl : function(select, doc, curUrl) {
@@ -202,7 +175,6 @@ var VNSharing = {
     }
     return null;
   },
-  
   //Write the image from the the url returned by the getListImages() function.
   //The function getListImages can return an url which is not the source of the
   //image. The src of the image is set by this function.
@@ -211,36 +183,30 @@ var VNSharing = {
     //This function runs in the DOM of the current consulted page.
   	$( image ).attr( "src", urlImg );
   },
-  
-  //If it is possible to know if an image is a credit page or something which 
+  //If it is possible to know if an image is a credit page or something which
   //must not be displayed as a book, just return true and the image will stand alone
   //img is the DOM object of the image
   isImageInOneCol : function(img, doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     return false;
   },
-  
-  //This function can return a preexisting select from the page to fill the 
+  //This function can return a preexisting select from the page to fill the
   //chapter select of the navigation bar. It avoids to load the chapters
   getMangaSelectFromPage : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     var res = [];
     var mg = $("#navsubbar a:first", doc).attr("href");
-    
     $("#selectChapter option", doc).each(function(index) {
       $(this).val(mg + "/" + $(this).val());
     });
-    
     return $("#selectChapter", doc);
   },
-  
   //This function is called when the manga is full loaded. Just do what you want here...
   doAfterMangaLoaded : function(doc, curUrl) {
     //This function runs in the DOM of the current consulted page.
     $("body > div:empty", doc).remove();
   }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("VNSharing", VNSharing);

--- a/Vortex.js
+++ b/Vortex.js
@@ -133,7 +133,6 @@ var Vortex = {
 		$("#page", doc).css("max-width", "none");
 	},
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Vortex Scans", Vortex);

--- a/WhuaMangas.js
+++ b/WhuaMangas.js
@@ -124,7 +124,6 @@ var WhuaMangas = {
       $("body > div:empty", doc).remove();
    }
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Whua! Mangás", WhuaMangas);

--- a/amanteanime.js
+++ b/amanteanime.js
@@ -102,7 +102,6 @@ var amanteanime = {
     return null;
   },
 }
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("amanteanime", amanteanime);

--- a/kireicake.js
+++ b/kireicake.js
@@ -128,7 +128,6 @@ var kireicake = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Kirei Cake", kireicake);

--- a/mangapanda.js
+++ b/mangapanda.js
@@ -151,7 +151,6 @@ var mangapanda = {
         $("body > div:empty", doc).remove();
     }
 };
-
 // Call registerMangaObject to be known by includer
 if (typeof registerMangaObject == 'function') {
 	registerMangaObject("Manga Panda", mangapanda);


### PR DESCRIPTION
Fixed Batoto not working on the new AJAX loader they use. It's not as smooth as it was before, but that is since we can no longer simply just grab the image URL.

Fixed MangaFox not always grabbing the image correctly. Also made sure images on the manga list aren't loaded (since they aren't needed).

Added a .gitattributes file to help normalize line endings for any future pull requests (This is the reason why the PR has so many changed files).

