### PR TITLE
MangaFox doesn't always use mini. in thumbnail URLs

### DIFF
--- a/MangaFox.js
+++ b/MangaFox.js
@@ -189,7 +189,7 @@ var MangaFox = {
             success: function(objResponse) {
                 var div = document.createElement("div");
                 div.innerHTML = objResponse;
-                var src = $('#image').attr('src') || $("meta[property='og:image']", div).attr("content").replace("thumbnails/mini.", "compressed/");
+                var src = $('#image').attr('src') || $("meta[property='og:image']", div).attr("content").replace(/thumbnails\/(?:mini.)?/, "compressed/");
                 $(image).attr("src", src);
             }
         });


### PR DESCRIPTION
MangaFox seems to have removed the mini. from thumbnails filenames, causing the replace to fail.