### PR TITLE
Fix MangaFox always loading image from current page

### DIFF
--- a/MangaFox.js
+++ b/MangaFox.js
@@ -187,9 +187,7 @@ var MangaFox = {
         $.ajax({
             url: urlImg,
             success: function(objResponse) {
-                var div = document.createElement("div");
-                div.innerHTML = objResponse;
-                var src = $('#image').attr('src') || $("img[id='image']", div).attr("src");
+                var src = $('#image', objResponse).attr('src');
 		        $(image).attr("src", src);
             },
             error: function() {


### PR DESCRIPTION
In the function '**getImageFromPageAndWrite**' we are trying to retrieve the image src from a specified page.
Doing `$('#image').attr('src')` was always fetching the image from the current page instead of the one specified in '**urlImg**'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allmangasreader-dev/mirrors/31)
<!-- Reviewable:end -->
